### PR TITLE
Loss In HyperSpace

### DIFF
--- a/embedding_converter/src/models/embedding_converter.py
+++ b/embedding_converter/src/models/embedding_converter.py
@@ -4,7 +4,7 @@ from torch import Tensor, nn
 
 class EmbeddingConverter(nn.Module):
 	def __init__(self) -> None:
-		super(EmbeddingConverter, self).__init__()
+		super().__init__()
 		self.layers = self.create_layers()
 		self.leaky_relu = nn.LeakyReLU()
 

--- a/embedding_converter/src/training.py
+++ b/embedding_converter/src/training.py
@@ -28,8 +28,6 @@ class EmbeddingConverterTrainer(lightning.LightningModule):
 		self.embedding_converter = EmbeddingConverter()
 		self.source_embedder = torch.jit.load(source_path, map_location = 'cpu') # type:ignore[no-untyped-call]
 		self.target_embedder = torch.jit.load(target_path, map_location = 'cpu') # type:ignore[no-untyped-call]
-		self.source_embedder.eval()
-		self.target_embedder.eval()
 		self.mse_loss = nn.MSELoss()
 
 	def forward(self, source_embedding : Embedding) -> Embedding:

--- a/embedding_converter/src/training.py
+++ b/embedding_converter/src/training.py
@@ -40,9 +40,9 @@ class EmbeddingConverterTrainer(lightning.LightningModule):
 			source_embedding = self.source_embedder(batch)
 			target_embedding = self.target_embedder(batch)
 		output_embedding = self(source_embedding)
-		loss_training = self.mse_loss(output_embedding, target_embedding)
-		self.log('loss_training', loss_training, prog_bar = True)
-		return loss_training
+		training_loss = self.mse_loss(output_embedding, target_embedding)
+		self.log('training_loss', training_loss, prog_bar = True)
+		return training_loss
 
 	def validation_step(self, batch : Batch, batch_index : int) -> Tensor:
 		with torch.no_grad():
@@ -63,7 +63,7 @@ class EmbeddingConverterTrainer(lightning.LightningModule):
 			'lr_scheduler':
 			{
 				'scheduler': scheduler,
-				'monitor': 'loss_training',
+				'monitor': 'training_loss',
 				'interval': 'epoch',
 				'frequency': 1
 			}
@@ -102,7 +102,7 @@ def create_trainer() -> Trainer:
 		callbacks =
 		[
 			ModelCheckpoint(
-				monitor = 'loss_training',
+				monitor = 'training_loss',
 				dirpath = output_directory_path,
 				filename = output_file_pattern,
 				every_n_epochs = 10,

--- a/face_swapper/README.md
+++ b/face_swapper/README.md
@@ -65,8 +65,8 @@ kernel_size = 4
 [training.losses]
 adversarial_weight = 1.5
 attribute_weight = 10
-reconstruction_weight = 15
-identity_weight = 15
+reconstruction_weight = 20
+identity_weight = 20
 pose_weight = 0
 gaze_weight = 0
 ```

--- a/face_swapper/README.md
+++ b/face_swapper/README.md
@@ -40,7 +40,7 @@ split_ratio = 0.9995
 
 ```
 [training.model]
-id_embedder_path = .models/id_embedder.pt
+embedder_path = .models/arcface.pt
 landmarker_path = .models/landmarker.pt
 motion_extractor_path = .models/motion_extractor.pt
 ```
@@ -99,7 +99,7 @@ opset_version = 15
 ```
 [inferencing]
 generator_path = .outputs/last.ckpt
-id_embedder_path = .models/id_embedder.pt
+embedder_path = .models/arcface.pt
 source_path = .assets/source.jpg
 target_path = .assets/target.jpg
 output_path = .outputs/output.jpg

--- a/face_swapper/README.md
+++ b/face_swapper/README.md
@@ -63,12 +63,12 @@ kernel_size = 4
 
 ```
 [training.losses]
-weight_adversarial = 1.5
-weight_identity = 15
-weight_attribute = 10
-weight_reconstruction = 15
-weight_pose = 0
-weight_gaze = 0
+adversarial_weight = 1.5
+attribute_weight = 10
+reconstruction_weight = 15
+identity_weight = 15
+pose_weight = 0
+gaze_weight = 0
 ```
 
 ```

--- a/face_swapper/config.ini
+++ b/face_swapper/config.ini
@@ -25,12 +25,12 @@ num_discriminators =
 kernel_size =
 
 [training.losses]
-weight_adversarial =
-weight_identity =
-weight_attribute =
-weight_reconstruction =
-weight_pose =
-weight_gaze =
+adversarial_weight =
+attribute_weight =
+reconstruction_weight =
+identity_weight =
+pose_weight =
+gaze_weight =
 
 [training.trainer]
 learning_rate =

--- a/face_swapper/src/helper.py
+++ b/face_swapper/src/helper.py
@@ -2,19 +2,19 @@ import numpy
 import torch
 from torch import Tensor, nn
 
-from .types import EmbedderModule, Embedding, Padding, VisionFrame, VisionTensor
+from .types import EmbedderModule, Embedding, Padding, VisionFrame
 
 
-def convert_to_vision_tensor(vision_frame : VisionFrame) -> VisionTensor:
-	vision_tensor = torch.from_numpy(vision_frame[:, :, ::-1].transpose(2, 0, 1).astype(numpy.float32))
-	vision_tensor = vision_tensor / 255.0
-	vision_tensor = (vision_tensor - 0.5) * 2
-	vision_tensor = vision_tensor.unsqueeze(0)
-	return vision_tensor
+def convert_to_tensor(vision_frame : VisionFrame) -> Tensor:
+	output_tensor = torch.from_numpy(vision_frame[:, :, ::-1].transpose(2, 0, 1).astype(numpy.float32))
+	output_tensor = output_tensor / 255.0
+	output_tensor = (output_tensor - 0.5) * 2
+	output_tensor = output_tensor.unsqueeze(0)
+	return output_tensor
 
 
-def convert_to_vision_frame(vision_tensor : VisionTensor) -> VisionFrame:
-	vision_frame = vision_tensor.detach().cpu().numpy()[0]
+def convert_to_vision_frame(input_tensor : Tensor) -> VisionFrame:
+	vision_frame = input_tensor.detach().cpu().numpy()[0]
 	vision_frame = vision_frame.transpose(1, 2, 0)
 	vision_frame = (vision_frame + 1) * 127.5
 	vision_frame = vision_frame.clip(0, 255).astype(numpy.uint8)

--- a/face_swapper/src/helper.py
+++ b/face_swapper/src/helper.py
@@ -34,13 +34,13 @@ def hinge_fake_loss(input_tensor : Tensor) -> Tensor:
 	return fake_loss
 
 
-def calc_id_embedding(id_embedder : EmbedderModule, vision_tensor : VisionTensor, padding : Padding) -> Embedding:
-	crop_vision_tensor = vision_tensor[:, :, 15 : 241, 15 : 241]
-	crop_vision_tensor = nn.functional.interpolate(crop_vision_tensor, size = (112, 112), mode = 'area')
-	crop_vision_tensor[:, :, :padding[0], :] = 0
-	crop_vision_tensor[:, :, 112 - padding[1]:, :] = 0
-	crop_vision_tensor[:, :, :, :padding[2]] = 0
-	crop_vision_tensor[:, :, :, 112 - padding[3]:] = 0
-	source_embedding = id_embedder(crop_vision_tensor)
-	source_embedding = nn.functional.normalize(source_embedding, p = 2)
-	return source_embedding
+def calc_embedding(embedder : EmbedderModule, input_tensor : Tensor, padding : Padding) -> Embedding:
+	crop_tensor = input_tensor[:, :, 15: 241, 15: 241]
+	crop_tensor = nn.functional.interpolate(crop_tensor, size = (112, 112), mode = 'area')
+	crop_tensor[:, :, :padding[0], :] = 0
+	crop_tensor[:, :, 112 - padding[1]:, :] = 0
+	crop_tensor[:, :, :, :padding[2]] = 0
+	crop_tensor[:, :, :, 112 - padding[3]:] = 0
+	embedding = embedder(crop_tensor)
+	embedding = nn.functional.normalize(embedding, p = 2)
+	return embedding

--- a/face_swapper/src/helper.py
+++ b/face_swapper/src/helper.py
@@ -22,18 +22,6 @@ def convert_to_vision_frame(vision_tensor : VisionTensor) -> VisionFrame:
 	return vision_frame
 
 
-def hinge_real_loss(input_tensor : Tensor) -> Tensor:
-	real_loss = torch.relu(1 - input_tensor)
-	real_loss = real_loss.mean(dim = [ 1, 2, 3 ])
-	return real_loss
-
-
-def hinge_fake_loss(input_tensor : Tensor) -> Tensor:
-	fake_loss = torch.relu(input_tensor + 1)
-	fake_loss = fake_loss.mean(dim = [ 1, 2, 3 ])
-	return fake_loss
-
-
 def calc_embedding(embedder : EmbedderModule, input_tensor : Tensor, padding : Padding) -> Embedding:
 	crop_tensor = input_tensor[:, :, 15: 241, 15: 241]
 	crop_tensor = nn.functional.interpolate(crop_tensor, size = (112, 112), mode = 'area')

--- a/face_swapper/src/inferencing.py
+++ b/face_swapper/src/inferencing.py
@@ -3,7 +3,7 @@ import configparser
 import cv2
 import torch
 
-from .helper import calc_embedding, convert_to_vision_frame, convert_to_vision_tensor
+from .helper import calc_embedding, convert_to_vision_frame, convert_to_tensor
 from .models.generator import Generator
 from .types import EmbedderModule, GeneratorModule, VisionFrame
 
@@ -12,11 +12,11 @@ CONFIG.read('config.ini')
 
 
 def run_swap(generator : GeneratorModule, embedder : EmbedderModule, source_vision_frame : VisionFrame, target_vision_frame : VisionFrame) -> VisionFrame:
-	source_vision_tensor = convert_to_vision_tensor(source_vision_frame)
-	target_vision_tensor = convert_to_vision_tensor(target_vision_frame)
-	source_embedding = calc_embedding(embedder, source_vision_tensor, (0, 0, 0, 0))
-	output_vision_tensor = generator(source_embedding, target_vision_tensor)[0]
-	output_vision_frame = convert_to_vision_frame(output_vision_tensor)
+	source_tensor = convert_to_tensor(source_vision_frame)
+	target_tensor = convert_to_tensor(target_vision_frame)
+	source_embedding = calc_embedding(embedder, source_tensor, (0, 0, 0, 0))
+	output_tensor = generator(source_embedding, target_tensor)[0]
+	output_vision_frame = convert_to_vision_frame(output_tensor)
 	return output_vision_frame
 
 

--- a/face_swapper/src/inferencing.py
+++ b/face_swapper/src/inferencing.py
@@ -3,7 +3,7 @@ import configparser
 import cv2
 import torch
 
-from .helper import calc_embedding, convert_to_vision_frame, convert_to_tensor
+from .helper import calc_embedding, convert_to_tensor, convert_to_vision_frame
 from .models.generator import Generator
 from .types import EmbedderModule, GeneratorModule, VisionFrame
 

--- a/face_swapper/src/models/discriminator.py
+++ b/face_swapper/src/models/discriminator.py
@@ -11,7 +11,7 @@ CONFIG.read('config.ini')
 
 class Discriminator(nn.Module):
 	def __init__(self) -> None:
-		super(Discriminator, self).__init__()
+		super().__init__()
 		self.avg_pool = nn.AvgPool2d(kernel_size = 3, stride = 2, padding = (1, 1), count_include_pad = False)
 		self.discriminators = self.create_discriminators()
 

--- a/face_swapper/src/models/generator.py
+++ b/face_swapper/src/models/generator.py
@@ -12,7 +12,7 @@ CONFIG.read('config.ini')
 
 class Generator(nn.Module):
 	def __init__(self) -> None:
-		super(Generator, self).__init__()
+		super().__init__()
 		encoder_type = CONFIG.get('training.model.generator', 'encoder_type')
 		id_channels = CONFIG.getint('training.model.generator', 'id_channels')
 		num_blocks = CONFIG.getint('training.model.generator', 'num_blocks')

--- a/face_swapper/src/models/loss.py
+++ b/face_swapper/src/models/loss.py
@@ -28,9 +28,9 @@ class DiscriminatorLoss(nn.Module):
 			negative_tensor = torch.relu(1 - discriminator_source_tensor[0]).mean(dim = [ 1, 2, 3 ])
 			negative_tensors.append(negative_tensor)
 
-		discriminator_positive_loss = torch.stack(positive_tensors).mean()
-		discriminator_negative_loss = torch.stack(negative_tensors).mean()
-		discriminator_loss = (discriminator_positive_loss + discriminator_negative_loss) * 0.5
+		positive_loss = torch.stack(positive_tensors).mean()
+		negative_loss = torch.stack(negative_tensors).mean()
+		discriminator_loss = (positive_loss + negative_loss) * 0.5
 		return discriminator_loss
 
 

--- a/face_swapper/src/models/loss.py
+++ b/face_swapper/src/models/loss.py
@@ -6,151 +6,10 @@ from pytorch_msssim import ssim
 from torch import Tensor, nn
 
 from ..helper import calc_embedding
-from ..types import Attributes, Batch, DiscriminatorLossSet, DiscriminatorOutputs, FaceLandmark203, GeneratorLossSet, LossTensor, SwapAttributes, TargetAttributes, VisionTensor
+from ..types import Attributes, FaceLandmark203
 
 CONFIG = configparser.ConfigParser()
 CONFIG.read('config.ini')
-
-
-def hinge_real_loss(input_tensor : Tensor) -> Tensor:
-	real_loss = torch.relu(1 - input_tensor)
-	real_loss = real_loss.mean(dim = [ 1, 2, 3 ])
-	return real_loss
-
-
-def hinge_fake_loss(input_tensor : Tensor) -> Tensor:
-	fake_loss = torch.relu(input_tensor + 1)
-	fake_loss = fake_loss.mean(dim = [ 1, 2, 3 ])
-	return fake_loss
-
-
-class FaceSwapperLoss:
-	def __init__(self) -> None:
-		embedder_path = CONFIG.get('training.model', 'embedder_path')
-		landmarker_path = CONFIG.get('training.model', 'landmarker_path')
-		motion_extractor_path = CONFIG.get('training.model', 'motion_extractor_path')
-		self.batch_size = CONFIG.getint('training.loader', 'batch_size')
-		self.mse_loss = nn.MSELoss()
-		self.embedder = torch.jit.load(embedder_path, map_location = 'cpu') # type:ignore[no-untyped-call]
-		self.landmarker = torch.jit.load(landmarker_path, map_location = 'cpu') # type:ignore[no-untyped-call]
-		self.motion_extractor = torch.jit.load(motion_extractor_path, map_location = 'cpu') # type:ignore[no-untyped-call]
-
-	def calc_generator_loss(self, swap_tensor : VisionTensor, target_attributes : TargetAttributes, swap_attributes : SwapAttributes, discriminator_outputs : DiscriminatorOutputs, batch : Batch) -> GeneratorLossSet:
-		weight_adversarial = CONFIG.getfloat('training.losses', 'adversarial_weight')
-		weight_identity = CONFIG.getfloat('training.losses', 'identity_weight')
-		weight_attribute = CONFIG.getfloat('training.losses', 'attribute_weight')
-		weight_reconstruction = CONFIG.getfloat('training.losses', 'reconstruction_weight')
-		weight_pose = CONFIG.getfloat('training.losses', 'pose_weight')
-		weight_gaze = CONFIG.getfloat('training.losses', 'gaze_weight')
-		source_tensor, target_tensor = batch
-		is_same_person = torch.tensor(0) if torch.equal(source_tensor, target_tensor) else torch.tensor(1)
-		generator_loss_set =\
-		{
-			'loss_adversarial': self.calc_adversarial_loss(discriminator_outputs),
-			'loss_identity': self.calc_identity_loss(source_tensor, swap_tensor),
-			'loss_attribute': self.calc_attribute_loss(target_attributes, swap_attributes),
-			'loss_reconstruction': self.calc_reconstruction_loss(swap_tensor, target_tensor, is_same_person)
-		}
-
-		generator_loss_set['loss_pose'] = self.calc_pose_loss(swap_tensor, target_tensor)
-		generator_loss_set['loss_gaze'] = self.calc_gaze_loss(swap_tensor, target_tensor)
-
-		generator_loss_set['loss_generator'] = generator_loss_set.get('loss_adversarial') * weight_adversarial
-		generator_loss_set['loss_generator'] += generator_loss_set.get('loss_identity') * weight_identity
-		generator_loss_set['loss_generator'] += generator_loss_set.get('loss_attribute') * weight_attribute
-		generator_loss_set['loss_generator'] += generator_loss_set.get('loss_reconstruction') * weight_reconstruction
-		generator_loss_set['loss_generator'] += generator_loss_set.get('loss_pose') * weight_pose
-		generator_loss_set['loss_generator'] += generator_loss_set.get('loss_gaze') * weight_gaze
-		return generator_loss_set
-
-	def hinge_real_loss(input_tensor: Tensor) -> Tensor:
-		real_loss = torch.relu(1 - input_tensor)
-		real_loss = real_loss.mean(dim = [1, 2, 3])
-		return real_loss
-
-	def hinge_fake_loss(input_tensor: Tensor) -> Tensor:
-		fake_loss = torch.relu(input_tensor + 1)
-		fake_loss = fake_loss.mean(dim = [1, 2, 3])
-		return fake_loss
-
-	def calc_discriminator_loss(self, real_discriminator_outputs : DiscriminatorOutputs, fake_discriminator_outputs : DiscriminatorOutputs) -> DiscriminatorLossSet:
-		discriminator_loss_set = {}
-		loss_fakes = []
-
-		for fake_discriminator_output in fake_discriminator_outputs:
-			loss_fakes.append(hinge_fake_loss(fake_discriminator_output[0]))
-
-		loss_trues = []
-
-		for true_discriminator_output in real_discriminator_outputs:
-			loss_trues.append(hinge_real_loss(true_discriminator_output[0]))
-
-		loss_fake = torch.stack(loss_fakes).mean()
-		loss_true = torch.stack(loss_trues).mean()
-		discriminator_loss_set['loss_discriminator'] = (loss_true + loss_fake) * 0.5
-		return discriminator_loss_set
-
-	def calc_adversarial_loss(self, discriminator_outputs : DiscriminatorOutputs) -> LossTensor:
-		loss_adversarials = []
-
-		for discriminator_output in discriminator_outputs:
-			loss_adversarials.append(hinge_real_loss(discriminator_output[0]).mean())
-
-		loss_adversarial = torch.stack(loss_adversarials).mean()
-		return loss_adversarial
-
-	def calc_attribute_loss(self, target_attributes : TargetAttributes, swap_attributes : SwapAttributes) -> LossTensor:
-		loss_attributes = []
-
-		for swap_attribute, target_attribute in zip(swap_attributes, target_attributes):
-			loss_attributes.append(torch.mean(torch.pow(swap_attribute - target_attribute, 2).reshape(self.batch_size, -1), dim = 1).mean())
-
-		loss_attribute = torch.stack(loss_attributes).mean() * 0.5
-		return loss_attribute
-
-	def calc_reconstruction_loss(self, swap_tensor : VisionTensor, target_tensor : VisionTensor, is_same_person : Tensor) -> LossTensor:
-		loss_reconstruction = torch.pow(swap_tensor - target_tensor, 2).reshape(self.batch_size, -1)
-		loss_reconstruction = torch.mean(loss_reconstruction, dim = 1) * 0.5
-		loss_reconstruction = torch.sum(loss_reconstruction * is_same_person) / (is_same_person.sum() + 1e-4)
-		loss_ssim = 1 - ssim(swap_tensor, target_tensor, data_range = float(torch.max(swap_tensor) - torch.min(swap_tensor))).mean()
-		loss_reconstruction = (loss_reconstruction + loss_ssim) * 0.5
-		return loss_reconstruction
-
-	def calc_identity_loss(self, source_tensor : VisionTensor, swap_tensor : VisionTensor) -> LossTensor:
-		swap_embedding = calc_embedding(self.embedder, swap_tensor, (30, 0, 10, 10))
-		source_embedding = calc_embedding(self.embedder, source_tensor, (30, 0, 10, 10))
-		loss_identity = (1 - torch.cosine_similarity(source_embedding, swap_embedding)).mean()
-		return loss_identity
-
-	def calc_pose_loss(self, swap_tensor : VisionTensor, target_tensor : VisionTensor) -> LossTensor:
-		swap_motion_features = self.get_pose_features(swap_tensor)
-		target_motion_features = self.get_pose_features(target_tensor)
-		loss_pose = torch.tensor(0).to(swap_tensor.device).to(swap_tensor.dtype)
-
-		for swap_motion_feature, target_motion_feature in zip(swap_motion_features, target_motion_features):
-			loss_pose += self.mse_loss(swap_motion_feature, target_motion_feature)
-
-		return loss_pose
-
-	def calc_gaze_loss(self, swap_tensor : VisionTensor, target_tensor : VisionTensor) -> LossTensor:
-		swap_landmark = self.get_face_landmarks(swap_tensor)
-		target_landmark = self.get_face_landmarks(target_tensor)
-		left_gaze_loss = self.mse_loss(swap_landmark[:, 198], target_landmark[:, 198])
-		right_gaze_loss = self.mse_loss(swap_landmark[:, 197], target_landmark[:, 197])
-		gaze_loss = left_gaze_loss + right_gaze_loss
-		return gaze_loss
-
-	def get_face_landmarks(self, vision_tensor : VisionTensor) -> FaceLandmark203:
-		vision_tensor_norm = (vision_tensor + 1) * 0.5
-		vision_tensor_norm = nn.functional.interpolate(vision_tensor_norm, size = (224, 224), mode = 'bilinear')
-		landmarks = self.landmarker(vision_tensor_norm)[2].view(-1, 203, 2)
-		return landmarks
-
-	def get_pose_features(self, vision_tensor : Tensor) -> Tuple[Tensor, Tensor, Tensor]:
-		vision_tensor_norm = (vision_tensor + 1) * 0.5
-		pitch, yaw, roll, translation, expression, scale, _ = self.motion_extractor(vision_tensor_norm)
-		rotation = torch.cat([ pitch, yaw, roll ], dim = 1)
-		return translation, scale, rotation
 
 
 class DiscriminatorLoss(nn.Module):
@@ -270,8 +129,8 @@ class PoseLoss(nn.Module):
 		return pose_loss, weighted_pose_loss
 
 	def get_motion_features(self, input_tensor : Tensor) -> Tuple[Tensor, Tensor, Tensor]:
-		vision_tensor_norm = (input_tensor + 1) * 0.5
-		pitch, yaw, roll, translation, expression, scale, _ = self.motion_extractor(vision_tensor_norm)
+		input_tensor = (input_tensor + 1) * 0.5
+		pitch, yaw, roll, translation, expression, scale, _ = self.motion_extractor(input_tensor)
 		rotation = torch.cat([ pitch, yaw, roll ], dim = 1)
 		return translation, scale, rotation
 
@@ -283,7 +142,7 @@ class GazeLoss(nn.Module):
 		self.landmarker = torch.jit.load(landmarker_path, map_location = 'cpu') # type:ignore[no-untyped-call]
 		self.mse_loss = nn.MSELoss()
 
-	def calc(self, target_tensor : VisionTensor, output_tensor : Tensor, ) -> Tuple[Tensor, Tensor]:
+	def calc(self, target_tensor : Tensor, output_tensor : Tensor, ) -> Tuple[Tensor, Tensor]:
 		gaze_weight = CONFIG.getfloat('training.losses', 'gaze_weight')
 		output_face_landmark = self.detect_face_landmark(output_tensor)
 		target_face_landmark = self.detect_face_landmark(target_tensor)

--- a/face_swapper/src/models/loss.py
+++ b/face_swapper/src/models/loss.py
@@ -1,6 +1,5 @@
 import configparser
 from typing import List, Tuple
-from warnings import deprecated
 
 import torch
 from pytorch_msssim import ssim
@@ -79,7 +78,6 @@ class FaceSwapperLoss:
 		discriminator_loss_set['loss_discriminator'] = (loss_true + loss_fake) * 0.5
 		return discriminator_loss_set
 
-	@deprecated
 	def calc_adversarial_loss(self, discriminator_outputs : DiscriminatorOutputs) -> LossTensor:
 		loss_adversarials = []
 
@@ -98,7 +96,6 @@ class FaceSwapperLoss:
 		loss_attribute = torch.stack(loss_attributes).mean() * 0.5
 		return loss_attribute
 
-	@deprecated
 	def calc_reconstruction_loss(self, swap_tensor : VisionTensor, target_tensor : VisionTensor, is_same_person : Tensor) -> LossTensor:
 		loss_reconstruction = torch.pow(swap_tensor - target_tensor, 2).reshape(self.batch_size, -1)
 		loss_reconstruction = torch.mean(loss_reconstruction, dim = 1) * 0.5
@@ -107,7 +104,6 @@ class FaceSwapperLoss:
 		loss_reconstruction = (loss_reconstruction + loss_ssim) * 0.5
 		return loss_reconstruction
 
-	@deprecated
 	def calc_identity_loss(self, source_tensor : VisionTensor, swap_tensor : VisionTensor) -> LossTensor:
 		swap_embedding = calc_embedding(self.embedder, swap_tensor, (30, 0, 10, 10))
 		source_embedding = calc_embedding(self.embedder, source_tensor, (30, 0, 10, 10))

--- a/face_swapper/src/models/loss.py
+++ b/face_swapper/src/models/loss.py
@@ -36,12 +36,12 @@ class FaceSwapperLoss:
 		self.motion_extractor = torch.jit.load(motion_extractor_path, map_location = 'cpu') # type:ignore[no-untyped-call]
 
 	def calc_generator_loss(self, swap_tensor : VisionTensor, target_attributes : TargetAttributes, swap_attributes : SwapAttributes, discriminator_outputs : DiscriminatorOutputs, batch : Batch) -> GeneratorLossSet:
-		weight_adversarial = CONFIG.getfloat('training.losses', 'weight_adversarial')
-		weight_identity = CONFIG.getfloat('training.losses', 'weight_identity')
-		weight_attribute = CONFIG.getfloat('training.losses', 'weight_attribute')
-		weight_reconstruction = CONFIG.getfloat('training.losses', 'weight_reconstruction')
-		weight_pose = CONFIG.getfloat('training.losses', 'weight_pose')
-		weight_gaze = CONFIG.getfloat('training.losses', 'weight_gaze')
+		weight_adversarial = CONFIG.getfloat('training.losses', 'adversarial_weight')
+		weight_identity = CONFIG.getfloat('training.losses', 'identity_weight')
+		weight_attribute = CONFIG.getfloat('training.losses', 'attribute_weight')
+		weight_reconstruction = CONFIG.getfloat('training.losses', 'reconstruction_weight')
+		weight_pose = CONFIG.getfloat('training.losses', 'pose_weight')
+		weight_gaze = CONFIG.getfloat('training.losses', 'gaze_weight')
 		source_tensor, target_tensor = batch
 		is_same_person = torch.tensor(0) if torch.equal(source_tensor, target_tensor) else torch.tensor(1)
 		generator_loss_set =\

--- a/face_swapper/src/models/loss.py
+++ b/face_swapper/src/models/loss.py
@@ -150,7 +150,7 @@ class AdversarialLoss(torch.nn.Module):
 		temp_tensors = []
 
 		for discriminator_output_tensor in discriminator_output_tensors:
-			temp_tensor = torch.relu(1 - discriminator_output_tensor[0]).mean()
+			temp_tensor = torch.relu(1 - discriminator_output_tensor[0]).mean(dim = [ 1, 2, 3 ]).mean()
 			temp_tensors.append(temp_tensor)
 
 		loss = torch.stack(temp_tensors).mean()

--- a/face_swapper/src/models/loss.py
+++ b/face_swapper/src/models/loss.py
@@ -147,7 +147,6 @@ class ReconstructionLoss(torch.nn.Module):
 
 	def calc(self, source_tensor : Tensor, target_tensor : Tensor, output_tensor : Tensor) -> Tensor:
 		batch_size = CONFIG.getint('training.loader', 'batch_size')
-
 		loss_tensor = torch.pow(output_tensor - target_tensor, 2).reshape(batch_size, -1)
 		loss_tensor = torch.mean(loss_tensor, dim = 1) * 0.5
 

--- a/face_swapper/src/networks/attribute_modulator.py
+++ b/face_swapper/src/networks/attribute_modulator.py
@@ -1,7 +1,7 @@
 import torch
 from torch import Tensor, nn
 
-from ..types import Embedding, TargetAttributes
+from ..types import Attributes, Embedding
 
 
 class AADGenerator(nn.Module):
@@ -17,7 +17,7 @@ class AADGenerator(nn.Module):
 		self.res_block_7 = AADResBlock(128, 64, 64, id_channels, num_blocks)
 		self.res_block_8 = AADResBlock(64, 3, 64, id_channels, num_blocks)
 
-	def forward(self, target_attributes : TargetAttributes, source_embedding : Embedding) -> Tensor:
+	def forward(self, target_attributes : Attributes, source_embedding : Embedding) -> Tensor:
 		feature_map = self.upsample(source_embedding)
 		feature_map_1 = nn.functional.interpolate(self.res_block_1(feature_map, target_attributes[0], source_embedding), scale_factor = 2, mode = 'bilinear', align_corners = False)
 		feature_map_2 = nn.functional.interpolate(self.res_block_2(feature_map_1, target_attributes[1], source_embedding), scale_factor = 2, mode = 'bilinear', align_corners = False)
@@ -59,10 +59,10 @@ class AADSequential(nn.Module):
 		super().__init__()
 		self.layers = nn.ModuleList(args)
 
-	def forward(self, feature_map : Tensor, attribute_embedding : Embedding, id_embedding : Embedding) -> Tensor:
+	def forward(self, feature_map : Tensor, attribute_embedding : Embedding, identity_embedding : Embedding) -> Tensor:
 		for layer in self.layers:
 			if isinstance(layer, AADLayer):
-				feature_map = layer(feature_map, attribute_embedding, id_embedding)
+				feature_map = layer(feature_map, attribute_embedding, identity_embedding)
 			else:
 				feature_map = layer(feature_map)
 		return feature_map

--- a/face_swapper/src/networks/attribute_modulator.py
+++ b/face_swapper/src/networks/attribute_modulator.py
@@ -6,7 +6,7 @@ from ..types import Embedding, TargetAttributes
 
 class AADGenerator(nn.Module):
 	def __init__(self, id_channels : int, num_blocks : int) -> None:
-		super(AADGenerator, self).__init__()
+		super().__init__()
 		self.upsample = PixelShuffleUpsample(id_channels, 1024 * 4)
 		self.res_block_1 = AADResBlock(1024, 1024, 1024, id_channels, num_blocks)
 		self.res_block_2 = AADResBlock(1024, 1024, 2048, id_channels, num_blocks)
@@ -56,7 +56,7 @@ class AADLayer(nn.Module):
 
 class AADSequential(nn.Module):
 	def __init__(self, *args : nn.Module) -> None:
-		super(AADSequential, self).__init__()
+		super().__init__()
 		self.layers = nn.ModuleList(args)
 
 	def forward(self, feature_map : Tensor, attribute_embedding : Embedding, id_embedding : Embedding) -> Tensor:
@@ -70,7 +70,7 @@ class AADSequential(nn.Module):
 
 class AADResBlock(nn.Module):
 	def __init__(self, input_channels : int, output_channels : int, attribute_channels : int, id_channels : int, num_blocks : int) -> None:
-		super(AADResBlock, self).__init__()
+		super().__init__()
 		self.input_channels = input_channels
 		self.output_channels = output_channels
 		self.prepare_primary_add_blocks(input_channels, attribute_channels, id_channels, output_channels, num_blocks)
@@ -111,7 +111,7 @@ class AADResBlock(nn.Module):
 
 class PixelShuffleUpsample(nn.Module):
 	def __init__(self, input_channels : int, output_channels : int) -> None:
-		super(PixelShuffleUpsample, self).__init__()
+		super().__init__()
 		self.conv = nn.Conv2d(in_channels = input_channels, out_channels = output_channels, kernel_size = 3, padding = 1)
 		self.pixel_shuffle = nn.PixelShuffle(upscale_factor = 2)
 

--- a/face_swapper/src/networks/nld.py
+++ b/face_swapper/src/networks/nld.py
@@ -5,7 +5,7 @@ from torch import Tensor, nn
 
 class NLD(nn.Module):
 	def __init__(self, input_channels : int, num_filters : int, num_layers : int, kernel_size : int) -> None:
-		super(NLD, self).__init__()
+		super().__init__()
 		self.nld = self.create_nld(input_channels, num_filters, num_layers, kernel_size)
 
 	@staticmethod

--- a/face_swapper/src/networks/unet.py
+++ b/face_swapper/src/networks/unet.py
@@ -7,7 +7,7 @@ from torchvision import models
 
 class UNet(nn.Module):
 	def __init__(self) -> None:
-		super(UNet, self).__init__()
+		super().__init__()
 		self.down_samples = self.create_down_samples(self)
 		self.up_samples = self.create_up_samples()
 
@@ -87,7 +87,7 @@ class UNetPro(UNet):
 
 class UpSample(nn.Module):
 	def __init__(self, input_channels : int, output_channels : int) -> None:
-		super(UpSample, self).__init__()
+		super().__init__()
 		self.conv_transpose = nn.ConvTranspose2d(in_channels = input_channels, out_channels = output_channels, kernel_size = 4, stride = 2, padding = 1, bias = False)
 		self.batch_norm = nn.BatchNorm2d(output_channels)
 		self.leaky_relu = nn.LeakyReLU(0.1, inplace = True)
@@ -102,7 +102,7 @@ class UpSample(nn.Module):
 
 class DownSample(nn.Module):
 	def __init__(self, input_channels : int, output_channels : int) -> None:
-		super(DownSample, self).__init__()
+		super().__init__()
 		self.conv = nn.Conv2d(in_channels = input_channels, out_channels = output_channels, kernel_size = 4, stride = 2, padding = 1, bias = False)
 		self.batch_norm = nn.BatchNorm2d(output_channels)
 		self.leaky_relu = nn.LeakyReLU(0.1, inplace = True)

--- a/face_swapper/src/training.py
+++ b/face_swapper/src/training.py
@@ -62,12 +62,12 @@ class FaceSwapperTrainer(lightning.LightningModule):
 		generator_output_attributes = self.generator.get_attributes(generator_output_tensor)
 		discriminator_output_tensors = self.discriminator(generator_output_tensor)
 
-		adversarial_loss, weighted_adversarial_loss = self.adversarial_loss.calc(discriminator_output_tensors)
-		attribute_loss, weighted_attribute_loss = self.attribute_loss.calc(target_attributes, generator_output_attributes)
-		reconstruction_loss, weighted_reconstruction_loss = self.reconstruction_loss.calc(source_tensor, target_tensor, generator_output_tensor)
-		identity_loss, weighted_identity_loss = self.identity_loss.calc(generator_output_tensor, source_tensor)
-		pose_loss, weighted_pose_loss = self.pose_loss.calc(target_tensor, generator_output_tensor)
-		gaze_loss, weighted_gaze_loss = self.gaze_loss.calc(target_tensor, generator_output_tensor)
+		adversarial_loss, weighted_adversarial_loss = self.adversarial_loss(discriminator_output_tensors)
+		attribute_loss, weighted_attribute_loss = self.attribute_loss(target_attributes, generator_output_attributes)
+		reconstruction_loss, weighted_reconstruction_loss = self.reconstruction_loss(source_tensor, target_tensor, generator_output_tensor)
+		identity_loss, weighted_identity_loss = self.identity_loss(generator_output_tensor, source_tensor)
+		pose_loss, weighted_pose_loss = self.pose_loss(target_tensor, generator_output_tensor)
+		gaze_loss, weighted_gaze_loss = self.gaze_loss(target_tensor, generator_output_tensor)
 		generator_loss = weighted_adversarial_loss + weighted_attribute_loss + weighted_reconstruction_loss + weighted_identity_loss + weighted_pose_loss
 
 		generator_optimizer.zero_grad()
@@ -76,7 +76,7 @@ class FaceSwapperTrainer(lightning.LightningModule):
 
 		discriminator_source_tensors = self.discriminator(source_tensor)
 		discriminator_output_tensors = self.discriminator(generator_output_tensor.detach())
-		discriminator_loss = self.discriminator_loss.calc(discriminator_source_tensors, discriminator_output_tensors)
+		discriminator_loss = self.discriminator_loss(discriminator_source_tensors, discriminator_output_tensors)
 
 		discriminator_optimizer.zero_grad()
 		self.manual_backward(discriminator_loss)

--- a/face_swapper/src/training.py
+++ b/face_swapper/src/training.py
@@ -88,7 +88,7 @@ class FaceSwapperTrainer(lightning.LightningModule, FaceSwapperLoss):
 		generator_loss = weighted_adversarial_loss + weighted_reconstruction_loss + weighted_identity_loss
 
 		self.log('generator_loss_new', generator_loss, prog_bar = True)
-		self.log('adversarial_loss_new', adversarial_loss, prog_bar = True)
+		self.log('loss_adversarial_new', adversarial_loss, prog_bar = True)
 		self.log('loss_reconstruction_new', reconstruction_loss)
 		self.log('loss_identity_new', identity_loss)
 		return generator_loss_set.get('loss_generator')

--- a/face_swapper/src/training.py
+++ b/face_swapper/src/training.py
@@ -16,7 +16,7 @@ from .dataset import DynamicDataset
 from .helper import calc_embedding
 from .models.discriminator import Discriminator
 from .models.generator import Generator
-from .models.loss import FaceSwapperLoss, IdentityLoss
+from .models.loss import FaceSwapperLoss, IdentityLoss, ReconstructionLoss
 from .types import Batch, Embedding, VisionTensor
 
 CONFIG = configparser.ConfigParser()
@@ -31,6 +31,7 @@ class FaceSwapperTrainer(lightning.LightningModule, FaceSwapperLoss):
 
 		self.generator = Generator()
 		self.discriminator = Discriminator()
+		self.reconstruction_loss = ReconstructionLoss()
 		self.identity_loss = IdentityLoss()
 		self.automatic_optimization = automatic_optimization
 
@@ -76,18 +77,24 @@ class FaceSwapperTrainer(lightning.LightningModule, FaceSwapperLoss):
 		self.log('loss_adversarial', generator_loss_set.get('loss_adversarial'))
 		self.log('loss_attribute', generator_loss_set.get('loss_attribute'))
 		self.log('loss_identity', generator_loss_set.get('loss_identity'), prog_bar = True)
-		self.log('loss_reconstruction', generator_loss_set.get('loss_reconstruction'))
+		self.log('loss_reconstruction', generator_loss_set.get('loss_reconstruction'), prog_bar = True)
 
-		identity_loss = self.identity_loss.calc_loss(generator_output_tensor, source_tensor)
-		generator_loss = self.calc_generator_loss_new(identity_loss)
+		reconstruction_loss = self.reconstruction_loss.calc(source_tensor, target_tensor, generator_output_tensor)
+		identity_loss = self.identity_loss.calc(generator_output_tensor, source_tensor)
+		generator_loss = self.calc_generator_loss_new(reconstruction_loss, identity_loss)
 
-		self.log('loss_generator_new', generator_loss, prog_bar = True)
+		self.log('generator_loss_new', generator_loss, prog_bar = True)
+		self.log('loss_reconstruction_new', reconstruction_loss, prog_bar = True)
 		self.log('loss_identity_new', identity_loss, prog_bar = True)
 		return generator_loss_set.get('loss_generator')
 
-	def calc_generator_loss_new(self, identity_loss : Tensor) -> Tensor:
-		weight_identity = CONFIG.getfloat('training.losses', 'weight_identity')
-		generator_loss = identity_loss * weight_identity
+	@staticmethod
+	def calc_generator_loss_new(reconstruction_loss : Tensor, identity_loss : Tensor) -> Tensor:
+		reconstruction_weight = CONFIG.getfloat('training.losses', 'reconstruction_weight')
+		identity_weight = CONFIG.getfloat('training.losses', 'identity_weight')
+
+		generator_loss = reconstruction_loss * reconstruction_weight
+		generator_loss += identity_loss * identity_weight
 
 		return generator_loss
 

--- a/face_swapper/src/training.py
+++ b/face_swapper/src/training.py
@@ -85,7 +85,7 @@ class FaceSwapperTrainer(lightning.LightningModule, FaceSwapperLoss):
 		adversarial_loss, weighted_adversarial_loss = self.adversarial_loss.calc(discriminator_output_tensors)
 		reconstruction_loss, weighted_reconstruction_loss = self.reconstruction_loss.calc(source_tensor, target_tensor, generator_output_tensor)
 		identity_loss, weighted_identity_loss = self.identity_loss.calc(generator_output_tensor, source_tensor)
-		generator_loss = weighted_adversarial_loss+ weighted_reconstruction_loss + weighted_identity_loss
+		generator_loss = weighted_adversarial_loss + weighted_reconstruction_loss + weighted_identity_loss
 
 		self.log('generator_loss_new', generator_loss, prog_bar = True)
 		self.log('adversarial_loss_new', adversarial_loss, prog_bar = True)

--- a/face_swapper/src/types.py
+++ b/face_swapper/src/types.py
@@ -1,5 +1,4 @@
-from collections import OrderedDict
-from typing import Any, Dict, List, Tuple, TypeAlias
+from typing import Any, Tuple, TypeAlias
 
 from numpy.typing import NDArray
 from torch import Tensor

--- a/face_swapper/src/types.py
+++ b/face_swapper/src/types.py
@@ -7,23 +7,13 @@ from torch.nn import Module
 
 Batch : TypeAlias = Tuple[Tensor, Tensor]
 
-SwapAttributes : TypeAlias = Tuple[Tensor, ...]
-TargetAttributes : TypeAlias = Tuple[Tensor, ...]
-DiscriminatorOutputs : TypeAlias = List[List[Tensor]]
-
 Attributes : TypeAlias = Tuple[Tensor, ...]
 Embedding : TypeAlias = Tensor
 FaceLandmark203 : TypeAlias = Tensor
 
-StateSet : TypeAlias = OrderedDict[str, Any]
 Padding : TypeAlias = Tuple[int, int, int, int]
 
 VisionFrame : TypeAlias = NDArray[Any]
-LossTensor : TypeAlias = Tensor
-VisionTensor : TypeAlias = Tensor
-
-GeneratorLossSet : TypeAlias = Dict[str, Tensor]
-DiscriminatorLossSet : TypeAlias = Dict[str, Tensor]
 
 GeneratorModule : TypeAlias = Module
 EmbedderModule : TypeAlias = Module


### PR DESCRIPTION
1. Replace old loss class with multiple new loss classes
2. New loss classes return actual loss and weighted loss
3. Compare new and old graphs in branch [refactor/loss-in-space](https://github.com/facefusion/facefusion-labs/tree/refactor/loss-in-space)
4. Ban VisionTensor naming
5. Clean types
6. Remove useless `_init_` params
7. Rename weight in config
8. Rename id_embedder to just embedder
9. Kill hinge_real_loss and hinge_fake_loss helper
10. Use pose_loss = torch.stack(temp_tensors).mean() over .sum()