### PR TITLE
New config approach

### DIFF
--- a/embedding_converter/src/dataset.py
+++ b/embedding_converter/src/dataset.py
@@ -1,15 +1,19 @@
 import glob
+from configparser import ConfigParser
 
 from torch import Tensor
 from torch.utils.data import Dataset
 from torchvision import io, transforms
 
-from .types import Batch, Config
+from .types import Batch
 
 
 class StaticDataset(Dataset[Tensor]):
-	def __init__(self, config : Config) -> None:
-		self.config = config
+	def __init__(self, config : ConfigParser) -> None:
+		self.config =\
+		{
+			'file_pattern': config.get('training.dataset', 'file_pattern')
+		}
 		self.file_paths = glob.glob(self.config.get('file_pattern'))
 		self.transforms = self.compose_transforms()
 

--- a/embedding_converter/src/dataset.py
+++ b/embedding_converter/src/dataset.py
@@ -9,10 +9,10 @@ from .types import Batch
 
 
 class StaticDataset(Dataset[Tensor]):
-	def __init__(self, config : ConfigParser) -> None:
+	def __init__(self, config_parser : ConfigParser) -> None:
 		self.config =\
 		{
-			'file_pattern': config.get('training.dataset', 'file_pattern')
+			'file_pattern': config_parser.get('training.dataset', 'file_pattern')
 		}
 		self.file_paths = glob.glob(self.config.get('file_pattern'))
 		self.transforms = self.compose_transforms()

--- a/embedding_converter/src/dataset.py
+++ b/embedding_converter/src/dataset.py
@@ -4,12 +4,13 @@ from torch import Tensor
 from torch.utils.data import Dataset
 from torchvision import io, transforms
 
-from .types import Batch
+from .types import Batch, Config
 
 
 class StaticDataset(Dataset[Tensor]):
-	def __init__(self, file_pattern : str) -> None:
-		self.file_paths = glob.glob(file_pattern)
+	def __init__(self, config : Config) -> None:
+		self.config = config
+		self.file_paths = glob.glob(self.config.get('file_pattern'))
 		self.transforms = self.compose_transforms()
 
 	def __getitem__(self, index : int) -> Batch:

--- a/embedding_converter/src/exporting.py
+++ b/embedding_converter/src/exporting.py
@@ -1,11 +1,11 @@
-import configparser
-from os import makedirs
+import os
+from configparser import ConfigParser
 
 import torch
 
 from .training import EmbeddingConverterTrainer
 
-CONFIG_PARSER = configparser.ConfigParser()
+CONFIG_PARSER = ConfigParser()
 CONFIG_PARSER.read('config.ini')
 
 
@@ -19,7 +19,7 @@ def export() -> None:
 		'opset_version': CONFIG_PARSER.getint('exporting', 'opset_version')
 	}
 
-	makedirs(config.get('directory_path'), exist_ok = True) # type:ignore[arg-type]
+	os.makedirs(config.get('directory_path'), exist_ok = True) # type:ignore[arg-type]
 	model = EmbeddingConverterTrainer.load_from_checkpoint(config.get('source_path'), map_location = 'cpu')
 	model.eval()
 	model.ir_version = torch.tensor(config.get('ir_version'))

--- a/embedding_converter/src/exporting.py
+++ b/embedding_converter/src/exporting.py
@@ -10,15 +10,18 @@ CONFIG.read('config.ini')
 
 
 def export() -> None:
-	directory_path = CONFIG.get('exporting', 'directory_path')
-	source_path = CONFIG.get('exporting', 'source_path')
-	target_path = CONFIG.get('exporting', 'target_path')
-	ir_version = CONFIG.getint('exporting', 'ir_version')
-	opset_version = CONFIG.getint('exporting', 'opset_version')
+	config =\
+	{
+		'directory_path': CONFIG.get('exporting', 'directory_path'),
+		'source_path': CONFIG.get('exporting', 'source_path'),
+		'target_path': CONFIG.get('exporting', 'target_path'),
+		'ir_version': CONFIG.getint('exporting', 'ir_version'),
+		'opset_version': CONFIG.getint('exporting', 'opset_version')
+	}
 
-	makedirs(directory_path, exist_ok = True)
-	model = EmbeddingConverterTrainer.load_from_checkpoint(source_path, map_location = 'cpu')
+	makedirs(config.get('directory_path'), exist_ok = True)
+	model = EmbeddingConverterTrainer.load_from_checkpoint(config.get('source_path'), map_location = 'cpu')
 	model.eval()
-	model.ir_version = torch.tensor(ir_version)
+	model.ir_version = torch.tensor(config.get('ir_version'))
 	input_tensor = torch.randn(1, 512)
-	torch.onnx.export(model, input_tensor, target_path, input_names = [ 'input' ], output_names = [ 'output' ], opset_version = opset_version)
+	torch.onnx.export(model, input_tensor, config.get('target_path'), input_names = [ 'input' ], output_names = [ 'output' ], opset_version = config.get('opset_version'))

--- a/embedding_converter/src/exporting.py
+++ b/embedding_converter/src/exporting.py
@@ -19,7 +19,7 @@ def export() -> None:
 		'opset_version': CONFIG.getint('exporting', 'opset_version')
 	}
 
-	makedirs(config.get('directory_path'), exist_ok = True)
+	makedirs(config.get('directory_path'), exist_ok = True) # type:ignore[arg-type]
 	model = EmbeddingConverterTrainer.load_from_checkpoint(config.get('source_path'), map_location = 'cpu')
 	model.eval()
 	model.ir_version = torch.tensor(config.get('ir_version'))

--- a/embedding_converter/src/exporting.py
+++ b/embedding_converter/src/exporting.py
@@ -5,18 +5,18 @@ import torch
 
 from .training import EmbeddingConverterTrainer
 
-CONFIG = configparser.ConfigParser()
-CONFIG.read('config.ini')
+CONFIG_PARSER = configparser.ConfigParser()
+CONFIG_PARSER.read('config.ini')
 
 
 def export() -> None:
 	config =\
 	{
-		'directory_path': CONFIG.get('exporting', 'directory_path'),
-		'source_path': CONFIG.get('exporting', 'source_path'),
-		'target_path': CONFIG.get('exporting', 'target_path'),
-		'ir_version': CONFIG.getint('exporting', 'ir_version'),
-		'opset_version': CONFIG.getint('exporting', 'opset_version')
+		'directory_path': CONFIG_PARSER.get('exporting', 'directory_path'),
+		'source_path': CONFIG_PARSER.get('exporting', 'source_path'),
+		'target_path': CONFIG_PARSER.get('exporting', 'target_path'),
+		'ir_version': CONFIG_PARSER.getint('exporting', 'ir_version'),
+		'opset_version': CONFIG_PARSER.getint('exporting', 'opset_version')
 	}
 
 	makedirs(config.get('directory_path'), exist_ok = True) # type:ignore[arg-type]

--- a/embedding_converter/src/training.py
+++ b/embedding_converter/src/training.py
@@ -1,9 +1,8 @@
-import configparser
 import os
+from configparser import ConfigParser
 from typing import Tuple
 
 import torch
-from configparser import ConfigParser
 from lightning import LightningModule, Trainer
 from lightning.pytorch.callbacks import ModelCheckpoint
 from lightning.pytorch.loggers import TensorBoardLogger
@@ -17,6 +16,7 @@ from .types import Batch, Embedding, OptimizerSet
 
 CONFIG_PARSER = ConfigParser()
 CONFIG_PARSER.read('config.ini')
+
 
 class EmbeddingConverterTrainer(LightningModule):
 	def __init__(self, config_parser : ConfigParser) -> None:

--- a/embedding_converter/src/training.py
+++ b/embedding_converter/src/training.py
@@ -139,7 +139,6 @@ def train() -> None:
 		}
 	}
 
-
 	if torch.cuda.is_available():
 		torch.set_float32_matmul_precision('high')
 

--- a/embedding_converter/src/training.py
+++ b/embedding_converter/src/training.py
@@ -121,7 +121,7 @@ def create_trainer() -> Trainer:
 
 
 def train() -> None:
-	config =\
+	config : Config =\
 	{
 		'dataset':
 		{

--- a/embedding_converter/src/training.py
+++ b/embedding_converter/src/training.py
@@ -22,12 +22,16 @@ CONFIG.read('config.ini')
 class EmbeddingConverterTrainer(lightning.LightningModule):
 	def __init__(self) -> None:
 		super(EmbeddingConverterTrainer, self).__init__()
-		source_path = CONFIG.get('training.model', 'source_path')
-		target_path = CONFIG.get('training.model', 'target_path')
+		self.config =\
+		{
+			'source_path': CONFIG.get('training.model', 'source_path'),
+			'target_path': CONFIG.get('training.model', 'target_path'),
+			'learning_rate': CONFIG.getfloat('training.trainer', 'learning_rate')
+		}
 
 		self.embedding_converter = EmbeddingConverter()
-		self.source_embedder = torch.jit.load(source_path, map_location = 'cpu') # type:ignore[no-untyped-call]
-		self.target_embedder = torch.jit.load(target_path, map_location = 'cpu') # type:ignore[no-untyped-call]
+		self.source_embedder = torch.jit.load(self.config.get('source_path'), map_location = 'cpu') # type:ignore[no-untyped-call]
+		self.target_embedder = torch.jit.load(self.config.get('target_path'), map_location = 'cpu') # type:ignore[no-untyped-call]
 		self.mse_loss = nn.MSELoss()
 
 	def forward(self, source_embedding : Embedding) -> Embedding:
@@ -51,8 +55,7 @@ class EmbeddingConverterTrainer(lightning.LightningModule):
 		return validation_score
 
 	def configure_optimizers(self) -> OptimizerConfig:
-		learning_rate = CONFIG.getfloat('training.trainer', 'learning_rate')
-		optimizer = torch.optim.Adam(self.parameters(), lr = learning_rate)
+		optimizer = torch.optim.Adam(self.parameters(), lr = self.config.get('learning_rate'))
 		scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer)
 		config =\
 		{
@@ -70,42 +73,52 @@ class EmbeddingConverterTrainer(lightning.LightningModule):
 
 
 def create_loaders(dataset : Dataset[Tensor]) -> Tuple[StatefulDataLoader[Tensor], StatefulDataLoader[Tensor]]:
-	batch_size = CONFIG.getint('training.loader', 'batch_size')
-	num_workers = CONFIG.getint('training.loader', 'num_workers')
+	config =\
+	{
+		'batch_size': CONFIG.getint('training.loader', 'batch_size'),
+		'num_workers': CONFIG.getint('training.loader', 'num_workers')
+	}
 
 	training_dataset, validate_dataset = split_dataset(dataset)
-	training_loader = StatefulDataLoader(training_dataset, batch_size = batch_size, shuffle = True, num_workers = num_workers, drop_last = True, pin_memory = True, persistent_workers = True)
-	validation_loader = StatefulDataLoader(validate_dataset, batch_size = batch_size, shuffle = False, num_workers = num_workers, pin_memory = True, persistent_workers = True)
+	training_loader = StatefulDataLoader(training_dataset, batch_size = config.get('batch_size'), shuffle = True, num_workers = config.get('num_workers'), drop_last = True, pin_memory = True, persistent_workers = True)
+	validation_loader = StatefulDataLoader(validate_dataset, batch_size = config.get('batch_size'), shuffle = False, num_workers = config.get('num_workers'), pin_memory = True, persistent_workers = True)
 	return training_loader, validation_loader
 
 
 def split_dataset(dataset : Dataset[Tensor]) -> Tuple[Dataset[Tensor], Dataset[Tensor]]:
-	split_ratio = CONFIG.getfloat('training.loader', 'split_ratio')
+	config =\
+	{
+		'split_ratio': CONFIG.getfloat('training.loader', 'split_ratio')
+	}
+
 	dataset_size = len(dataset) # type:ignore[arg-type]
-	training_size = int(dataset_size * split_ratio)
+	training_size = int(dataset_size * config.get('split_ratio'))
 	validation_size = int(dataset_size - training_size)
 	training_dataset, validate_dataset = random_split(dataset, [ training_size, validation_size ])
 	return training_dataset, validate_dataset
 
 
 def create_trainer() -> Trainer:
-	trainer_max_epochs = CONFIG.getint('training.trainer', 'max_epochs')
-	output_directory_path = CONFIG.get('training.output', 'directory_path')
-	output_file_pattern = CONFIG.get('training.output', 'file_pattern')
-	trainer_precision = CONFIG.get('training.trainer', 'precision')
+	config =\
+	{
+		'max_epochs': CONFIG.getint('training.trainer', 'max_epochs'),
+		'directory_path': CONFIG.get('training.output', 'directory_path'),
+		'file_pattern': CONFIG.get('training.output', 'file_pattern'),
+		'precision': CONFIG.get('training.trainer', 'precision')
+	}
 	logger = TensorBoardLogger('.logs', name = 'embedding_converter')
 
 	return Trainer(
 		logger = logger,
 		log_every_n_steps = 10,
-		max_epochs = trainer_max_epochs,
-		precision = trainer_precision, # type:ignore[arg-type]
+		max_epochs = config.get('max_epochs'),
+		precision = config.get('precision'), # type:ignore[arg-type]
 		callbacks =
 		[
 			ModelCheckpoint(
 				monitor = 'training_loss',
-				dirpath = output_directory_path,
-				filename = output_file_pattern,
+				dirpath = config.get('directory_path'),
+				filename = config.get('file_pattern'),
 				every_n_epochs = 1,
 				save_top_k = 3,
 				save_last = True
@@ -115,18 +128,21 @@ def create_trainer() -> Trainer:
 
 
 def train() -> None:
-	dataset_file_pattern = CONFIG.get('training.dataset', 'file_pattern')
-	output_resume_path = CONFIG.get('training.output', 'resume_path')
+	config =\
+	{
+		'file_pattern': CONFIG.get('training.dataset', 'file_pattern'),
+		'resume_path': CONFIG.get('training.output', 'resume_path')
+	}
 
 	if torch.cuda.is_available():
 		torch.set_float32_matmul_precision('high')
 
-	dataset = StaticDataset(dataset_file_pattern)
+	dataset = StaticDataset(config)
 	training_loader, validation_loader = create_loaders(dataset)
 	embedding_converter_trainer = EmbeddingConverterTrainer()
 	trainer = create_trainer()
 
-	if os.path.exists(output_resume_path):
-		trainer.fit(embedding_converter_trainer, training_loader, validation_loader, ckpt_path = output_resume_path)
+	if os.path.exists(config.get('resume_path')):
+		trainer.fit(embedding_converter_trainer, training_loader, validation_loader, ckpt_path = config.get('resume_path'))
 	else:
 		trainer.fit(embedding_converter_trainer, training_loader, validation_loader)

--- a/embedding_converter/src/training.py
+++ b/embedding_converter/src/training.py
@@ -121,7 +121,7 @@ def create_trainer() -> Trainer:
 
 
 def train() -> None:
-	config : ConfigSet =\
+	config_set : ConfigSet =\
 	{
 		'dataset':
 		{
@@ -133,7 +133,7 @@ def train() -> None:
 			'target_path': CONFIG.get('training.model', 'target_path'),
 			'learning_rate': CONFIG.getfloat('training.trainer', 'learning_rate')
 		},
-		'common':
+		'output':
 		{
 			'resume_path': CONFIG.get('training.output', 'resume_path')
 		}
@@ -142,12 +142,12 @@ def train() -> None:
 	if torch.cuda.is_available():
 		torch.set_float32_matmul_precision('high')
 
-	dataset = StaticDataset(config.get('dataset'))
+	dataset = StaticDataset(config_set.get('dataset'))
 	training_loader, validation_loader = create_loaders(dataset)
-	embedding_converter_trainer = EmbeddingConverterTrainer(config.get('trainer'))
+	embedding_converter_trainer = EmbeddingConverterTrainer(config_set.get('trainer'))
 	trainer = create_trainer()
 
-	if os.path.exists(config.get('common').get('resume_path')):
-		trainer.fit(embedding_converter_trainer, training_loader, validation_loader, ckpt_path = config.get('common').get('resume_path'))
+	if os.path.exists(config_set.get('output').get('resume_path')):
+		trainer.fit(embedding_converter_trainer, training_loader, validation_loader, ckpt_path = config_set.get('output').get('resume_path'))
 	else:
 		trainer.fit(embedding_converter_trainer, training_loader, validation_loader)

--- a/embedding_converter/src/training.py
+++ b/embedding_converter/src/training.py
@@ -12,7 +12,7 @@ from torchdata.stateful_dataloader import StatefulDataLoader
 
 from .dataset import StaticDataset
 from .models.embedding_converter import EmbeddingConverter
-from .types import Batch, Config, Embedding, OptimizerSet
+from .types import Batch, Config, ConfigSet, Embedding, OptimizerSet
 
 CONFIG = configparser.ConfigParser()
 CONFIG.read('config.ini')
@@ -121,7 +121,7 @@ def create_trainer() -> Trainer:
 
 
 def train() -> None:
-	config : Config =\
+	config : ConfigSet =\
 	{
 		'dataset':
 		{

--- a/embedding_converter/src/training.py
+++ b/embedding_converter/src/training.py
@@ -13,7 +13,7 @@ from torchdata.stateful_dataloader import StatefulDataLoader
 
 from .dataset import StaticDataset
 from .models.embedding_converter import EmbeddingConverter
-from .types import Batch, Embedding, OptimizerConfig
+from .types import Batch, Embedding, OptimizerSet
 
 CONFIG = configparser.ConfigParser()
 CONFIG.read('config.ini')
@@ -54,7 +54,7 @@ class EmbeddingConverterTrainer(lightning.LightningModule):
 		self.log('validation_score', validation_score, prog_bar = True)
 		return validation_score
 
-	def configure_optimizers(self) -> OptimizerConfig:
+	def configure_optimizers(self) -> OptimizerSet:
 		optimizer = torch.optim.Adam(self.parameters(), lr = self.config.get('learning_rate'))
 		scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer)
 		config =\

--- a/embedding_converter/src/training.py
+++ b/embedding_converter/src/training.py
@@ -129,7 +129,7 @@ def train() -> None:
 	{
 		'source_path': CONFIG.get('training.model', 'source_path'),
 		'target_path': CONFIG.get('training.model', 'target_path'),
-		'learning_rate': CONFIG.getfloat('training.trainer', 'learning_rate'),
+		'learning_rate': CONFIG.getfloat('training.trainer', 'learning_rate')
 	}
 	config_common =\
 	{

--- a/embedding_converter/src/training.py
+++ b/embedding_converter/src/training.py
@@ -50,7 +50,7 @@ class EmbeddingConverterTrainer(LightningModule):
 	def configure_optimizers(self) -> OptimizerSet:
 		optimizer = torch.optim.Adam(self.parameters(), lr = self.config.get('learning_rate'))
 		scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer)
-		config =\
+		optimizer_set =\
 		{
 			'optimizer': optimizer,
 			'lr_scheduler':
@@ -62,7 +62,7 @@ class EmbeddingConverterTrainer(LightningModule):
 			}
 		}
 
-		return config
+		return optimizer_set
 
 
 def create_loaders(dataset : Dataset[Tensor]) -> Tuple[StatefulDataLoader[Tensor], StatefulDataLoader[Tensor]]:
@@ -124,13 +124,16 @@ def train() -> None:
 	config_dataset =\
 	{
 		'file_pattern': CONFIG.get('training.dataset', 'file_pattern'),
-		'resume_path': CONFIG.get('training.output', 'resume_path')
 	}
 	config_trainer =\
 	{
 		'source_path': CONFIG.get('training.model', 'source_path'),
 		'target_path': CONFIG.get('training.model', 'target_path'),
-		'learning_rate': CONFIG.getfloat('training.trainer', 'learning_rate')
+		'learning_rate': CONFIG.getfloat('training.trainer', 'learning_rate'),
+	}
+	config_common =\
+	{
+		'resume_path': CONFIG.get('training.output', 'resume_path')
 	}
 
 	if torch.cuda.is_available():
@@ -141,7 +144,7 @@ def train() -> None:
 	embedding_converter_trainer = EmbeddingConverterTrainer(config_trainer)
 	trainer = create_trainer()
 
-	if os.path.exists(config_dataset.get('resume_path')):
-		trainer.fit(embedding_converter_trainer, training_loader, validation_loader, ckpt_path = config_dataset.get('resume_path'))
+	if os.path.exists(config_common.get('resume_path')):
+		trainer.fit(embedding_converter_trainer, training_loader, validation_loader, ckpt_path = config_common.get('resume_path'))
 	else:
 		trainer.fit(embedding_converter_trainer, training_loader, validation_loader)

--- a/embedding_converter/src/training.py
+++ b/embedding_converter/src/training.py
@@ -3,7 +3,7 @@ import os
 from typing import Tuple
 
 import torch
-from lightning import Trainer, LightningModule
+from lightning import LightningModule, Trainer
 from lightning.pytorch.callbacks import ModelCheckpoint
 from lightning.pytorch.loggers import TensorBoardLogger
 from torch import Tensor, nn
@@ -12,7 +12,7 @@ from torchdata.stateful_dataloader import StatefulDataLoader
 
 from .dataset import StaticDataset
 from .models.embedding_converter import EmbeddingConverter
-from .types import Batch, Embedding, OptimizerSet, Config
+from .types import Batch, Config, Embedding, OptimizerSet
 
 CONFIG = configparser.ConfigParser()
 CONFIG.read('config.ini')

--- a/embedding_converter/src/types.py
+++ b/embedding_converter/src/types.py
@@ -1,9 +1,10 @@
-from typing import Any, TypeAlias
+from typing import Any, Dict, TypeAlias
 
 from torch import Tensor
 
 Batch : TypeAlias = Tensor
 Embedding : TypeAlias = Tensor
 
-Config : TypeAlias = Any
+Config : TypeAlias = Dict[str, Any]
+ConfigSet : TypeAlias = Dict[str, Config]
 OptimizerSet : TypeAlias = Any

--- a/embedding_converter/src/types.py
+++ b/embedding_converter/src/types.py
@@ -1,8 +1,9 @@
-from typing import Any, TypeAlias
+from typing import Any, TypeAlias, Dict
 
 from torch import Tensor
 
 Batch : TypeAlias = Tensor
 Embedding : TypeAlias = Tensor
 
+Config : TypeAlias = Dict[str, Any]
 OptimizerConfig : TypeAlias = Any

--- a/embedding_converter/src/types.py
+++ b/embedding_converter/src/types.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, TypeAlias
+from typing import Any, TypeAlias
 
 from torch import Tensor
 

--- a/embedding_converter/src/types.py
+++ b/embedding_converter/src/types.py
@@ -7,4 +7,5 @@ Embedding : TypeAlias = Tensor
 
 Config : TypeAlias = Dict[str, Any]
 ConfigSet : TypeAlias = Dict[str, Config]
+
 OptimizerSet : TypeAlias = Any

--- a/embedding_converter/src/types.py
+++ b/embedding_converter/src/types.py
@@ -5,5 +5,5 @@ from torch import Tensor
 Batch : TypeAlias = Tensor
 Embedding : TypeAlias = Tensor
 
-Config : TypeAlias = Dict[str, Any]
+Config : TypeAlias = Any
 OptimizerSet : TypeAlias = Any

--- a/embedding_converter/src/types.py
+++ b/embedding_converter/src/types.py
@@ -1,11 +1,8 @@
-from typing import Any, Dict, TypeAlias
+from typing import Any, TypeAlias
 
 from torch import Tensor
 
 Batch : TypeAlias = Tensor
 Embedding : TypeAlias = Tensor
-
-Config : TypeAlias = Dict[str, Any]
-ConfigSet : TypeAlias = Dict[str, Config]
 
 OptimizerSet : TypeAlias = Any

--- a/embedding_converter/src/types.py
+++ b/embedding_converter/src/types.py
@@ -1,4 +1,4 @@
-from typing import Any, TypeAlias, Dict
+from typing import Any, Dict, TypeAlias
 
 from torch import Tensor
 
@@ -6,4 +6,4 @@ Batch : TypeAlias = Tensor
 Embedding : TypeAlias = Tensor
 
 Config : TypeAlias = Dict[str, Any]
-OptimizerConfig : TypeAlias = Any
+OptimizerSet : TypeAlias = Any

--- a/face_swapper/src/training.py
+++ b/face_swapper/src/training.py
@@ -3,10 +3,9 @@ import os
 import warnings
 from typing import Tuple, cast
 
-import lightning
 import torch
 import torchvision
-from lightning import Trainer
+from lightning import Trainer, LightningModule
 from lightning.pytorch.callbacks import ModelCheckpoint
 from lightning.pytorch.loggers import TensorBoardLogger
 from torch import Tensor, nn
@@ -26,7 +25,7 @@ CONFIG = configparser.ConfigParser()
 CONFIG.read('config.ini')
 
 
-class FaceSwapperTrainer(lightning.LightningModule):
+class FaceSwapperTrainer(LightningModule):
 	def __init__(self) -> None:
 		super().__init__()
 		embedder_path = CONFIG.get('training.model', 'embedder_path')

--- a/face_swapper/src/training.py
+++ b/face_swapper/src/training.py
@@ -5,7 +5,7 @@ from typing import Tuple, cast
 
 import torch
 import torchvision
-from lightning import Trainer, LightningModule
+from lightning import LightningModule, Trainer
 from lightning.pytorch.callbacks import ModelCheckpoint
 from lightning.pytorch.loggers import TensorBoardLogger
 from torch import Tensor, nn

--- a/face_swapper/src/training.py
+++ b/face_swapper/src/training.py
@@ -18,7 +18,7 @@ from .helper import calc_embedding
 from .models.discriminator import Discriminator
 from .models.generator import Generator
 from .models.loss import AdversarialLoss, AttributeLoss, DiscriminatorLoss, GazeLoss, IdentityLoss, MotionLoss, ReconstructionLoss
-from .types import Batch, BatchMode, Embedding, OptimizerConfig, WarpTemplate
+from .types import Batch, BatchMode, Embedding, OptimizerSet, WarpTemplate
 
 warnings.filterwarnings('ignore', category = UserWarning, module = 'torch')
 
@@ -52,7 +52,7 @@ class FaceSwapperTrainer(lightning.LightningModule):
 		output_tensor = self.generator(source_embedding, target_tensor)
 		return output_tensor
 
-	def configure_optimizers(self) -> Tuple[OptimizerConfig, OptimizerConfig]:
+	def configure_optimizers(self) -> Tuple[OptimizerSet, OptimizerSet]:
 		learning_rate = CONFIG.getfloat('training.trainer', 'learning_rate')
 		generator_optimizer = torch.optim.AdamW(self.generator.parameters(), lr = learning_rate, betas = (0.0, 0.999), weight_decay = 1e-4)
 		discriminator_optimizer = torch.optim.AdamW(self.discriminator.parameters(), lr = learning_rate, betas = (0.0, 0.999), weight_decay = 1e-4)

--- a/face_swapper/src/types.py
+++ b/face_swapper/src/types.py
@@ -18,6 +18,8 @@ GazerModule : TypeAlias = Module
 MotionExtractorModule : TypeAlias = Module
 
 Config : TypeAlias = Dict[str, Any]
+ConfigSet : TypeAlias = Dict[str, Config]
+
 OptimizerSet : TypeAlias = Any
 
 WarpTemplate = Literal['vgg_face_hq_to_arcface_128_v2', 'arcface_128_v2_to_arcface_112_v2']

--- a/face_swapper/src/types.py
+++ b/face_swapper/src/types.py
@@ -17,9 +17,6 @@ EmbedderModule : TypeAlias = Module
 GazerModule : TypeAlias = Module
 MotionExtractorModule : TypeAlias = Module
 
-Config : TypeAlias = Dict[str, Any]
-ConfigSet : TypeAlias = Dict[str, Config]
-
 OptimizerSet : TypeAlias = Any
 
 WarpTemplate = Literal['vgg_face_hq_to_arcface_128_v2', 'arcface_128_v2_to_arcface_112_v2']

--- a/face_swapper/src/types.py
+++ b/face_swapper/src/types.py
@@ -17,7 +17,8 @@ EmbedderModule : TypeAlias = Module
 GazerModule : TypeAlias = Module
 MotionExtractorModule : TypeAlias = Module
 
-OptimizerConfig : TypeAlias = Any
+Config : TypeAlias = Dict[str, Any]
+OptimizerSet : TypeAlias = Any
 
 WarpTemplate = Literal['vgg_face_hq_to_arcface_128_v2', 'arcface_128_v2_to_arcface_112_v2']
 WarpTemplateSet : TypeAlias = Dict[WarpTemplate, Tensor]


### PR DESCRIPTION
### Approach - Always define config in non-class methods

```python
def example() -> None
	config =\
	{
		'batch_size': CONFIG_PARSER.getint('training.loader', 'batch_size'),
		'num_workers': CONFIG_PARSER.getint('training.loader', 'num_workers')
	}
```

### Approach - Do not inject parsed configs

```python
class ExampleModule(nn.Module):
	def __init__(self, config : Config, embedder : EmbedderModule) -> None:
		self.config = config
		self.embedder = embedder
```

### Approach - Define config from injected ConfigParser

```python
ExampleTrainer(CONFIG_PARSER, embedder)
```

```python
class ExampleTrainer(LightningModule):
	def __init__(self, config_parser : ConfigParser) -> None:
		super().__init__()
		self.config =\
		{
			'source_path': config_parser.get('training.model', 'source_path'),
			'target_path': config_parser.get('training.model', 'target_path'),
			'learning_rate': config_parser.getfloat('training.trainer', 'learning_rate')
		}
```

### Why

- variables that contain a config are not immutable
- variables that contain a config do not represent it in the name
- mixing config parameters and depedency injection is a mess
- using CONFIG directly is too long
- decouple configparser from most classes and files
- class property polution can be reduced
- no direct access of config in forward() methods