### PR TITLE
Refactor/new config approach part2

### DIFF
--- a/embedding_converter/src/dataset.py
+++ b/embedding_converter/src/dataset.py
@@ -10,11 +10,8 @@ from .types import Batch
 
 class StaticDataset(Dataset[Tensor]):
 	def __init__(self, config_parser : ConfigParser) -> None:
-		self.config =\
-		{
-			'file_pattern': config_parser.get('training.dataset', 'file_pattern')
-		}
-		self.file_paths = glob.glob(self.config.get('file_pattern'))
+		self.config_file_pattern = config_parser.get('training.dataset', 'file_pattern')
+		self.file_paths = glob.glob(self.config_file_pattern)
 		self.transforms = self.compose_transforms()
 
 	def __getitem__(self, index : int) -> Batch:

--- a/embedding_converter/src/exporting.py
+++ b/embedding_converter/src/exporting.py
@@ -17,8 +17,7 @@ def export() -> None:
 	config_opset_version = CONFIG_PARSER.getint('exporting', 'opset_version')
 
 	os.makedirs(config_directory_path, exist_ok = True)
-	model = EmbeddingConverterTrainer.load_from_checkpoint(config_source_path, map_location = 'cpu')
-	model.eval()
+	model = EmbeddingConverterTrainer.load_from_checkpoint(config_source_path, map_location = 'cpu').eval()
 	model.ir_version = torch.tensor(config_ir_version)
 	input_tensor = torch.randn(1, 512)
 	torch.onnx.export(model, input_tensor, config_target_path, input_names = [ 'input' ], output_names = [ 'output' ], opset_version = config_opset_version)

--- a/embedding_converter/src/exporting.py
+++ b/embedding_converter/src/exporting.py
@@ -10,18 +10,15 @@ CONFIG_PARSER.read('config.ini')
 
 
 def export() -> None:
-	config =\
-	{
-		'directory_path': CONFIG_PARSER.get('exporting', 'directory_path'),
-		'source_path': CONFIG_PARSER.get('exporting', 'source_path'),
-		'target_path': CONFIG_PARSER.get('exporting', 'target_path'),
-		'ir_version': CONFIG_PARSER.getint('exporting', 'ir_version'),
-		'opset_version': CONFIG_PARSER.getint('exporting', 'opset_version')
-	}
+	config_directory_path = CONFIG_PARSER.get('exporting', 'directory_path')
+	config_source_path = CONFIG_PARSER.get('exporting', 'source_path')
+	config_target_path = CONFIG_PARSER.get('exporting', 'target_path')
+	config_ir_version = CONFIG_PARSER.getint('exporting', 'ir_version')
+	config_opset_version = CONFIG_PARSER.getint('exporting', 'opset_version')
 
-	os.makedirs(config.get('directory_path'), exist_ok = True) # type:ignore[arg-type]
-	model = EmbeddingConverterTrainer.load_from_checkpoint(config.get('source_path'), map_location = 'cpu')
+	os.makedirs(config_directory_path, exist_ok = True)
+	model = EmbeddingConverterTrainer.load_from_checkpoint(config_source_path, map_location = 'cpu')
 	model.eval()
-	model.ir_version = torch.tensor(config.get('ir_version'))
+	model.ir_version = torch.tensor(config_ir_version)
 	input_tensor = torch.randn(1, 512)
-	torch.onnx.export(model, input_tensor, config.get('target_path'), input_names = [ 'input' ], output_names = [ 'output' ], opset_version = config.get('opset_version'))
+	torch.onnx.export(model, input_tensor, config_target_path, input_names = [ 'input' ], output_names = [ 'output' ], opset_version = config_opset_version)

--- a/embedding_converter/src/training.py
+++ b/embedding_converter/src/training.py
@@ -25,8 +25,8 @@ class EmbeddingConverterTrainer(LightningModule):
 		self.config_target_path = config_parser.get('training.model', 'target_path')
 		self.config_learning_rate = config_parser.getfloat('training.trainer', 'learning_rate')
 		self.embedding_converter = EmbeddingConverter()
-		self.source_embedder = torch.jit.load(self.config_source_path, map_location = 'cpu')
-		self.target_embedder = torch.jit.load(self.config_target_path, map_location = 'cpu')
+		self.source_embedder = torch.jit.load(self.config_source_path, map_location = 'cpu').eval()
+		self.target_embedder = torch.jit.load(self.config_target_path, map_location = 'cpu').eval()
 		self.mse_loss = nn.MSELoss()
 
 	def forward(self, source_embedding : Embedding) -> Embedding:

--- a/face_swapper/src/dataset.py
+++ b/face_swapper/src/dataset.py
@@ -29,13 +29,13 @@ class DynamicDataset(Dataset[Tensor]):
 	def __getitem__(self, index : int) -> Batch:
 		file_path = self.file_paths[index]
 
-		if random.random() < self.config.get('batch_ratio'):
+		if random.random() < self.config.get('batch_ratio'): # type:ignore[operator]
 			if self.config.get('batch_mode') == 'equal':
-				return self.prepare_equal_batch(file_path)
+				return self.prepare_equal_batch(file_path) # type:ignore[arg-type]
 			if self.config.get('batch_mode') == 'same':
-				return self.prepare_same_batch(file_path)
+				return self.prepare_same_batch(file_path) # type:ignore[arg-type]
 
-		return self.prepare_different_batch(file_path)
+		return self.prepare_different_batch(file_path) # type:ignore[arg-type]
 
 	def __len__(self) -> int:
 		return len(self.file_paths)

--- a/face_swapper/src/dataset.py
+++ b/face_swapper/src/dataset.py
@@ -23,7 +23,7 @@ class DynamicDataset(Dataset[Tensor]):
 			'batch_ratio': config_parser.getfloat('training.dataset', 'batch_ratio'),
 		}
 		self.config_parser = config_parser
-		self.file_paths = glob.glob(self.config.get('file_pattern'))
+		self.file_paths = glob.glob(self.config.get('file_pattern')) # type:ignore[type-var]
 		self.transforms = self.compose_transforms()
 
 	def __getitem__(self, index : int) -> Batch:

--- a/face_swapper/src/dataset.py
+++ b/face_swapper/src/dataset.py
@@ -10,7 +10,7 @@ from torch.utils.data import Dataset
 from torchvision import io, transforms
 
 from .helper import warp_tensor
-from .types import Batch, WarpTemplate, BatchMode
+from .types import Batch, BatchMode, WarpTemplate
 
 
 class DynamicDataset(Dataset[Tensor]):

--- a/face_swapper/src/dataset.py
+++ b/face_swapper/src/dataset.py
@@ -16,7 +16,7 @@ from .types import Batch, BatchMode, WarpTemplate
 class DynamicDataset(Dataset[Tensor]):
 	def __init__(self, config_parser : ConfigParser) -> None:
 		self.config_file_pattern = config_parser.get('training.dataset', 'file_pattern')
-		self.config_transform_size = config_parser.get('training.dataset', 'transform_size')
+		self.config_transform_size = config_parser.getint('training.dataset', 'transform_size')
 		self.config_batch_mode = cast(BatchMode, config_parser.get('training.dataset', 'batch_mode'))
 		self.config_batch_ratio = config_parser.getfloat('training.dataset', 'batch_ratio')
 		self.config_parser = config_parser

--- a/face_swapper/src/exporting.py
+++ b/face_swapper/src/exporting.py
@@ -11,20 +11,16 @@ CONFIG_PARSER.read('config.ini')
 
 
 def export() -> None:
-	config =\
-	{
-		'directory_path': CONFIG_PARSER.get('exporting', 'directory_path'),
-		'source_path': CONFIG_PARSER.get('exporting', 'source_path'),
-		'target_path': CONFIG_PARSER.get('exporting', 'target_path'),
-		'target_size': CONFIG_PARSER.getint('exporting', 'target_size'),
-		'ir_version': CONFIG_PARSER.getint('exporting', 'ir_version'),
-		'opset_version': CONFIG_PARSER.getint('exporting', 'opset_version')
-	}
+	config_directory_path = CONFIG_PARSER.get('exporting', 'directory_path')
+	config_source_path = CONFIG_PARSER.get('exporting', 'source_path')
+	config_target_path = CONFIG_PARSER.get('exporting', 'target_path')
+	config_target_size = CONFIG_PARSER.getint('exporting', 'target_size')
+	config_ir_version = CONFIG_PARSER.getint('exporting', 'ir_version')
+	config_opset_version = CONFIG_PARSER.getint('exporting', 'opset_version')
 
-	os.makedirs(config.get('directory_path'), exist_ok = True) # type:ignore[arg-type]
-	model = FaceSwapperTrainer.load_from_checkpoint(config.get('source_path'), map_location = 'cpu')
-	model.eval()
-	model.ir_version = torch.tensor(config.get('ir_version'))
+	os.makedirs(config_directory_path, exist_ok = True)
+	model = FaceSwapperTrainer.load_from_checkpoint(config_source_path, map_location = 'cpu').eval()
+	model.ir_version = torch.tensor(config_ir_version)
 	source_tensor = torch.randn(1, 512)
-	target_tensor = torch.randn(1, 3, config.get('target_size'), config.get('target_size'))
-	torch.onnx.export(model, (source_tensor, target_tensor), config.get('target_path'), input_names = [ 'source', 'target' ], output_names = [ 'output' ], opset_version = config.get('opset_version'))
+	target_tensor = torch.randn(1, 3, config_target_size, config_target_size)
+	torch.onnx.export(model, (source_tensor, target_tensor), config_target_path, input_names = [ 'source', 'target' ], output_names = [ 'output' ], opset_version = config_opset_version)

--- a/face_swapper/src/exporting.py
+++ b/face_swapper/src/exporting.py
@@ -1,26 +1,30 @@
-import configparser
-from os import makedirs
+import os
+from configparser import ConfigParser
+
 
 import torch
 
 from .training import FaceSwapperTrainer
 
-CONFIG = configparser.ConfigParser()
-CONFIG.read('config.ini')
+CONFIG_PARSER = ConfigParser()
+CONFIG_PARSER.read('config.ini')
 
 
 def export() -> None:
-	directory_path = CONFIG.get('exporting', 'directory_path')
-	source_path = CONFIG.get('exporting', 'source_path')
-	target_path = CONFIG.get('exporting', 'target_path')
-	target_size = CONFIG.getint('exporting', 'target_size')
-	ir_version = CONFIG.getint('exporting', 'ir_version')
-	opset_version = CONFIG.getint('exporting', 'opset_version')
+	config =\
+	{
+		'directory_path': CONFIG_PARSER.get('exporting', 'directory_path'),
+		'source_path': CONFIG_PARSER.get('exporting', 'source_path'),
+		'target_path': CONFIG_PARSER.get('exporting', 'target_path'),
+		'target_size': CONFIG_PARSER.getint('exporting', 'target_size'),
+		'ir_version': CONFIG_PARSER.getint('exporting', 'ir_version'),
+		'opset_version': CONFIG_PARSER.getint('exporting', 'opset_version')
+	}
 
-	makedirs(directory_path, exist_ok = True)
-	model = FaceSwapperTrainer.load_from_checkpoint(source_path, map_location = 'cpu')
+	os.makedirs(config.get('directory_path'), exist_ok = True)
+	model = FaceSwapperTrainer.load_from_checkpoint(config.get('source_path'), map_location = 'cpu')
 	model.eval()
-	model.ir_version = torch.tensor(ir_version)
+	model.ir_version = torch.tensor(config.get('ir_version'))
 	source_tensor = torch.randn(1, 512)
-	target_tensor = torch.randn(1, 3, target_size, target_size)
-	torch.onnx.export(model, (source_tensor, target_tensor), target_path, input_names = [ 'source', 'target' ], output_names = [ 'output' ], opset_version = opset_version)
+	target_tensor = torch.randn(1, 3, config.get('target_size'), config.get('target_size'))
+	torch.onnx.export(model, (source_tensor, target_tensor), config.get('target_path'), input_names = [ 'source', 'target' ], output_names = [ 'output' ], opset_version = config.get('opset_version'))

--- a/face_swapper/src/exporting.py
+++ b/face_swapper/src/exporting.py
@@ -21,7 +21,7 @@ def export() -> None:
 		'opset_version': CONFIG_PARSER.getint('exporting', 'opset_version')
 	}
 
-	os.makedirs(config.get('directory_path'), exist_ok = True)
+	os.makedirs(config.get('directory_path'), exist_ok = True) # type:ignore[arg-type]
 	model = FaceSwapperTrainer.load_from_checkpoint(config.get('source_path'), map_location = 'cpu')
 	model.eval()
 	model.ir_version = torch.tensor(config.get('ir_version'))

--- a/face_swapper/src/inferencing.py
+++ b/face_swapper/src/inferencing.py
@@ -11,24 +11,20 @@ CONFIG_PARSER.read('config.ini')
 
 
 def infer() -> None:
-	config =\
-	{
-		'generator_path': CONFIG_PARSER.get('inferencing', 'generator_path'),
-		'embedder_path': CONFIG_PARSER.get('inferencing', 'embedder_path'),
-		'source_path': CONFIG_PARSER.get('inferencing', 'source_path'),
-		'target_path': CONFIG_PARSER.get('inferencing', 'target_path'),
-		'output_path': CONFIG_PARSER.get('inferencing', 'output_path')
-	}
+	config_generator_path = CONFIG_PARSER.get('inferencing', 'generator_path')
+	config_embedder_path = CONFIG_PARSER.get('inferencing', 'embedder_path')
+	config_source_path = CONFIG_PARSER.get('inferencing', 'source_path')
+	config_target_path = CONFIG_PARSER.get('inferencing', 'target_path')
+	config_output_path = CONFIG_PARSER.get('inferencing', 'output_path')
 
-	state_dict = torch.load(config.get('generator_path')).get('state_dict').get('generator')
+	state_dict = torch.load(config_generator_path).get('state_dict').get('generator')
 	generator = Generator(CONFIG_PARSER)
 	generator.load_state_dict(state_dict)
 	generator.eval()
-	embedder = torch.jit.load(config.get('embedder_path'), map_location = 'cpu') # type:ignore[no-untyped-call]
-	embedder.eval()
+	embedder = torch.jit.load(config_embedder_path, map_location = 'cpu').eval()
 
-	source_tensor = io.read_image(config.get('source_path'))
-	target_tensor = io.read_image(config.get('target_path'))
+	source_tensor = io.read_image(config_source_path)
+	target_tensor = io.read_image(config_target_path)
 	source_embedding = calc_embedding(embedder, source_tensor, (0, 0, 0, 0))
 	output_tensor = generator(source_embedding, target_tensor)[0]
-	io.write_jpeg(output_tensor, config.get('output_path'))
+	io.write_jpeg(output_tensor, config_output_path)

--- a/face_swapper/src/inferencing.py
+++ b/face_swapper/src/inferencing.py
@@ -24,7 +24,7 @@ def infer() -> None:
 	generator = Generator(CONFIG_PARSER)
 	generator.load_state_dict(state_dict)
 	generator.eval()
-	embedder = torch.jit.load(embedder_path, map_location = 'cpu') # type:ignore[no-untyped-call]
+	embedder = torch.jit.load(config.get('embedder_path'), map_location = 'cpu') # type:ignore[no-untyped-call]
 	embedder.eval()
 
 	source_tensor = io.read_image(config.get('source_path'))

--- a/face_swapper/src/inferencing.py
+++ b/face_swapper/src/inferencing.py
@@ -6,26 +6,29 @@ from torchvision import io
 from .helper import calc_embedding
 from .models.generator import Generator
 
-CONFIG = configparser.ConfigParser()
-CONFIG.read('config.ini')
+CONFIG_PARSER = configparser.ConfigParser()
+CONFIG_PARSER.read('config.ini')
 
 
 def infer() -> None:
-	generator_path = CONFIG.get('inferencing', 'generator_path')
-	embedder_path = CONFIG.get('inferencing', 'embedder_path')
-	source_path = CONFIG.get('inferencing', 'source_path')
-	target_path = CONFIG.get('inferencing', 'target_path')
-	output_path = CONFIG.get('inferencing', 'output_path')
+	config =\
+	{
+		'generator_path': CONFIG_PARSER.get('inferencing', 'generator_path'),
+		'embedder_path': CONFIG_PARSER.get('inferencing', 'embedder_path'),
+		'source_path': CONFIG_PARSER.get('inferencing', 'source_path'),
+		'target_path': CONFIG_PARSER.get('inferencing', 'target_path'),
+		'output_path': CONFIG_PARSER.get('inferencing', 'output_path')
+	}
 
-	state_dict = torch.load(generator_path).get('state_dict').get('generator')
-	generator = Generator()
+	state_dict = torch.load(config.get('generator_path')).get('state_dict').get('generator')
+	generator = Generator(CONFIG_PARSER)
 	generator.load_state_dict(state_dict)
 	generator.eval()
 	embedder = torch.jit.load(embedder_path, map_location = 'cpu') # type:ignore[no-untyped-call]
 	embedder.eval()
 
-	source_tensor = io.read_image(source_path)
-	target_tensor = io.read_image(target_path)
+	source_tensor = io.read_image(config.get('source_path'))
+	target_tensor = io.read_image(config.get('target_path'))
 	source_embedding = calc_embedding(embedder, source_tensor, (0, 0, 0, 0))
 	output_tensor = generator(source_embedding, target_tensor)[0]
-	io.write_jpeg(output_tensor, output_path)
+	io.write_jpeg(output_tensor, config.get('output_path'))

--- a/face_swapper/src/models/discriminator.py
+++ b/face_swapper/src/models/discriminator.py
@@ -17,7 +17,6 @@ class Discriminator(nn.Module):
 		self.avg_pool = nn.AvgPool2d(kernel_size = 3, stride = 2, padding = (1, 1), count_include_pad = False)
 		self.discriminators = self.create_discriminators()
 
-
 	def create_discriminators(self) -> nn.ModuleList:
 		discriminators = nn.ModuleList()
 

--- a/face_swapper/src/models/discriminator.py
+++ b/face_swapper/src/models/discriminator.py
@@ -9,10 +9,7 @@ from ..networks.nld import NLD
 class Discriminator(nn.Module):
 	def __init__(self, config_parser : ConfigParser) -> None:
 		super().__init__()
-		self.config =\
-		{
-			'num_discriminators': config_parser.getint('training.model.discriminator', 'num_discriminators')
-		}
+		self.config_num_discriminators = config_parser.getint('training.model.discriminator', 'num_discriminators')
 		self.config_parser = config_parser
 		self.avg_pool = nn.AvgPool2d(kernel_size = 3, stride = 2, padding = (1, 1), count_include_pad = False)
 		self.discriminators = self.create_discriminators()
@@ -20,7 +17,7 @@ class Discriminator(nn.Module):
 	def create_discriminators(self) -> nn.ModuleList:
 		discriminators = nn.ModuleList()
 
-		for _ in range(self.config.get('num_discriminators')):
+		for _ in range(self.config_num_discriminators):
 			discriminator = NLD(self.config_parser).sequences
 			discriminators.append(discriminator)
 

--- a/face_swapper/src/models/generator.py
+++ b/face_swapper/src/models/generator.py
@@ -1,4 +1,4 @@
-import configparser
+from configparser import ConfigParser
 
 from torch import Tensor, nn
 
@@ -6,20 +6,12 @@ from ..networks.aad import AAD
 from ..networks.unet import UNet
 from ..types import Attributes, Embedding
 
-CONFIG = configparser.ConfigParser()
-CONFIG.read('config.ini')
-
 
 class Generator(nn.Module):
-	def __init__(self) -> None:
+	def __init__(self, config_parser : ConfigParser) -> None:
 		super().__init__()
-		identity_channels = CONFIG.getint('training.model.generator', 'identity_channels')
-		output_channels = CONFIG.getint('training.model.generator', 'output_channels')
-		output_size = CONFIG.getint('training.model.generator', 'output_size')
-		num_blocks = CONFIG.getint('training.model.generator', 'num_blocks')
-
-		self.encoder = UNet(output_size)
-		self.generator = AAD(identity_channels, output_channels, output_size, num_blocks)
+		self.encoder = UNet(config_parser)
+		self.generator = AAD(config_parser)
 		self.encoder.apply(init_weight)
 		self.generator.apply(init_weight)
 

--- a/face_swapper/src/models/loss.py
+++ b/face_swapper/src/models/loss.py
@@ -53,31 +53,37 @@ class AdversarialLoss(nn.Module):
 
 
 class AttributeLoss(nn.Module):
-	def __init__(self) -> None:
+	def __init__(self, config_parser : ConfigParser) -> None:
 		super().__init__()
+		self.config =\
+		{
+			'batch_size': config_parser.getint('training.loader', 'batch_size'),
+			'attribute_weight': config_parser.getfloat('training.losses', 'attribute_weight')
+		}
 
 	def forward(self, target_attributes : Attributes, output_attributes : Attributes) -> Tuple[Tensor, Tensor]:
-		batch_size = CONFIG.getint('training.loader', 'batch_size')
-		attribute_weight = CONFIG.getfloat('training.losses', 'attribute_weight')
 		temp_tensors = []
 
 		for target_attribute, output_attribute in zip(target_attributes, output_attributes):
-			temp_tensor = torch.mean(torch.pow(output_attribute - target_attribute, 2).reshape(batch_size, -1), dim = 1).mean()
+			temp_tensor = torch.mean(torch.pow(output_attribute - target_attribute, 2).reshape(self.config.get('batch_size'), -1), dim = 1).mean()
 			temp_tensors.append(temp_tensor)
 
 		attribute_loss = torch.stack(temp_tensors).mean() * 0.5
-		weighted_attribute_loss = attribute_loss * attribute_weight
+		weighted_attribute_loss = attribute_loss * self.config.get('attribute_weight')
 		return attribute_loss, weighted_attribute_loss
 
 
 class ReconstructionLoss(nn.Module):
-	def __init__(self, embedder : EmbedderModule) -> None:
+	def __init__(self, config_parser : ConfigParser, embedder : EmbedderModule) -> None:
 		super().__init__()
+		self.config =\
+		{
+			'reconstruction_weight': config_parser.getfloat('training.losses', 'reconstruction_weight')
+		}
 		self.embedder = embedder
 		self.mse_loss = nn.MSELoss()
 
 	def forward(self, source_tensor : Tensor, target_tensor : Tensor, output_tensor : Tensor) -> Tuple[Tensor, Tensor]:
-		reconstruction_weight = CONFIG.getfloat('training.losses', 'reconstruction_weight')
 		source_embedding = calc_embedding(self.embedder, source_tensor, (0, 0, 0, 0))
 		target_embedding = calc_embedding(self.embedder, target_tensor, (0, 0, 0, 0))
 		has_similar_identity = torch.cosine_similarity(source_embedding, target_embedding) > 0.8
@@ -88,27 +94,35 @@ class ReconstructionLoss(nn.Module):
 		data_range = float(torch.max(output_tensor) - torch.min(output_tensor))
 		visual_loss = 1 - ssim(output_tensor, target_tensor, data_range = data_range).mean()
 		reconstruction_loss = (reconstruction_loss + visual_loss) * 0.5
-		weighted_reconstruction_loss = reconstruction_loss * reconstruction_weight
+		weighted_reconstruction_loss = reconstruction_loss * self.config.get('reconstruction_weight')
 		return reconstruction_loss, weighted_reconstruction_loss
 
 
 class IdentityLoss(nn.Module):
-	def __init__(self, embedder : EmbedderModule) -> None:
+	def __init__(self, config_parser : ConfigParser, embedder : EmbedderModule) -> None:
 		super().__init__()
+		self.config =\
+		{
+			'identity_weight': config_parser.getfloat('training.losses', 'identity_weight')
+		}
 		self.embedder = embedder
 
 	def forward(self, source_tensor : Tensor, output_tensor : Tensor) -> Tuple[Tensor, Tensor]:
-		identity_weight = CONFIG.getfloat('training.losses', 'identity_weight')
 		output_embedding = calc_embedding(self.embedder, output_tensor, (30, 0, 10, 10))
 		source_embedding = calc_embedding(self.embedder, source_tensor, (30, 0, 10, 10))
 		identity_loss = (1 - torch.cosine_similarity(source_embedding, output_embedding)).mean()
-		weighted_identity_loss = identity_loss * identity_weight
+		weighted_identity_loss = identity_loss * self.config.get('identity_weight')
 		return identity_loss, weighted_identity_loss
 
 
 class MotionLoss(nn.Module):
-	def __init__(self, motion_extractor : MotionExtractorModule):
+	def __init__(self, config_parser : ConfigParser, motion_extractor : MotionExtractorModule):
 		super().__init__()
+		self.config =\
+		{
+			'pose_weight': config_parser.getfloat('training.losses', 'pose_weight'),
+			'expression_weight': config_parser.getfloat('training.losses', 'expression_weight')
+		}
 		self.motion_extractor = motion_extractor
 		self.mse_loss = nn.MSELoss()
 
@@ -120,7 +134,6 @@ class MotionLoss(nn.Module):
 		return pose_loss, weighted_pose_loss, expression_loss, weighted_expression_loss
 
 	def calc_pose_loss(self, target_poses : Tuple[Tensor, ...], output_poses : Tuple[Tensor, ...]) -> Tuple[Tensor, Tensor]:
-		pose_weight = CONFIG.getfloat('training.losses', 'pose_weight')
 		temp_tensors = []
 
 		for target_pose, output_pose in zip(target_poses, output_poses):
@@ -128,13 +141,12 @@ class MotionLoss(nn.Module):
 			temp_tensors.append(temp_tensor)
 
 		pose_loss = torch.stack(temp_tensors).mean()
-		weighted_pose_loss = pose_loss * pose_weight
+		weighted_pose_loss = pose_loss * self.config.get('pose_weight')
 		return pose_loss, weighted_pose_loss
 
 	def calc_expression_loss(self, target_expression : Tensor, output_expression : Tensor) -> Tuple[Tensor, Tensor]:
-		expression_weight = CONFIG.getfloat('training.losses', 'expression_weight')
 		expression_loss = (1 - torch.cosine_similarity(target_expression, output_expression)).mean()
-		weighted_expression_loss = expression_loss * expression_weight
+		weighted_expression_loss = expression_loss * self.config.get('expression_weight')
 		return expression_loss, weighted_expression_loss
 
 	def get_motions(self, input_tensor : Tensor) -> Tuple[Tuple[Tensor, ...], Tensor]:
@@ -148,13 +160,17 @@ class MotionLoss(nn.Module):
 
 
 class GazeLoss(nn.Module):
-	def __init__(self, gazer : GazerModule) -> None:
+	def __init__(self, config_parser : ConfigParser, gazer : GazerModule) -> None:
 		super().__init__()
+		self.config =\
+		{
+			'gaze_weight': config_parser.getfloat('training.losses', 'gaze_weight'),
+			'output_size': config_parser.getint('training.model.generator', 'output_size')
+		}
 		self.gazer = gazer
 		self.l1_loss = nn.L1Loss()
 
 	def forward(self, target_tensor : Tensor, output_tensor : Tensor) -> Tuple[Tensor, Tensor]:
-		gaze_weight = CONFIG.getfloat('training.losses', 'gaze_weight')
 		output_pitch, output_yaw = self.detect_gaze(output_tensor)
 		target_pitch, target_yaw = self.detect_gaze(target_tensor)
 
@@ -162,12 +178,11 @@ class GazeLoss(nn.Module):
 		yaw_loss = self.l1_loss(output_yaw, target_yaw)
 
 		gaze_loss = (pitch_loss + yaw_loss) * 0.5
-		weighted_gaze_loss = gaze_loss * gaze_weight
+		weighted_gaze_loss = gaze_loss * self.config.get('gaze_weight')
 		return gaze_loss, weighted_gaze_loss
 
 	def detect_gaze(self, input_tensor : Tensor) -> Gaze:
-		output_size = CONFIG.getint('training.model.generator', 'output_size')
-		crop_sizes = (torch.tensor([ 0.235, 0.875, 0.0625, 0.8 ]) * output_size).int()
+		crop_sizes = (torch.tensor([ 0.235, 0.875, 0.0625, 0.8 ]) * self.config.get('output_size')).int()
 		crop_tensor = input_tensor[:, :, crop_sizes[0]:crop_sizes[1], crop_sizes[2]:crop_sizes[3]]
 		crop_tensor = (crop_tensor + 1) * 0.5
 		crop_tensor = transforms.Normalize(mean = [ 0.485, 0.456, 0.406 ], std = [ 0.229, 0.224, 0.225 ])(crop_tensor)

--- a/face_swapper/src/models/loss.py
+++ b/face_swapper/src/models/loss.py
@@ -107,7 +107,7 @@ class MotionLoss(nn.Module):
 	def __init__(self, config_parser : ConfigParser, motion_extractor : MotionExtractorModule):
 		super().__init__()
 		self.config_pose_weight = config_parser.getfloat('training.losses', 'pose_weight')
-		self.expression_weight = config_parser.getfloat('training.losses', 'expression_weight')
+		self.config_expression_weight = config_parser.getfloat('training.losses', 'expression_weight')
 		self.motion_extractor = motion_extractor
 		self.mse_loss = nn.MSELoss()
 

--- a/face_swapper/src/networks/aad.py
+++ b/face_swapper/src/networks/aad.py
@@ -1,3 +1,5 @@
+from configparser import ConfigParser
+
 import torch
 from torch import Tensor, nn
 
@@ -5,51 +7,55 @@ from ..types import Attributes, Embedding
 
 
 class AAD(nn.Module):
-	def __init__(self, identity_channels : int, output_channels : int, output_size : int, num_blocks : int) -> None:
+	def __init__(self, config_parser : ConfigParser) -> None:
 		super().__init__()
-		self.identity_channels = identity_channels
-		self.output_channels = output_channels
-		self.output_size = output_size
-		self.num_blocks = num_blocks
-		self.pixel_shuffle_up_sample = PixelShuffleUpSample(identity_channels, output_channels)
+		self.config =\
+		{
+			'identity_channels': config_parser.getint('training.model.generator', 'identity_channels'),
+			'output_channels': config_parser.getint('training.model.generator', 'output_channels'),
+			'output_size': config_parser.getint('training.model.generator', 'output_size'),
+			'num_blocks': config_parser.getint('training.model.generator', 'num_blocks')
+		}
+		self.config_parser = config_parser
+		self.pixel_shuffle_up_sample = PixelShuffleUpSample(self.config.get('identity_channels'), self.config.get('output_channels'))
 		self.layers = self.create_layers()
 
 	def create_layers(self) -> nn.ModuleList:
 		layers = nn.ModuleList()
 
-		if self.output_size == 128:
+		if self.config.get('output_size') == 128:
 			layers.extend(
 			[
-				AdaptiveFeatureModulation(512, 512, 512, self.identity_channels, self.num_blocks),
-				AdaptiveFeatureModulation(512, 512, 1024, self.identity_channels, self.num_blocks),
-				AdaptiveFeatureModulation(512, 512, 512, self.identity_channels, self.num_blocks),
+				AdaptiveFeatureModulation(512, 512, 512, self.config.get('identity_channels'), self.config.get('num_blocks')),
+				AdaptiveFeatureModulation(512, 512, 1024, self.config.get('identity_channels'), self.config.get('num_blocks')),
+				AdaptiveFeatureModulation(512, 512, 512, self.config.get('identity_channels'), self.config.get('num_blocks'))
 			])
 
-		if self.output_size == 256:
+		if self.config.get('output_size') == 256:
 			layers.extend(
 			[
-				AdaptiveFeatureModulation(1024, 1024, 1024, self.identity_channels, self.num_blocks),
-				AdaptiveFeatureModulation(1024, 1024, 2048, self.identity_channels, self.num_blocks),
-				AdaptiveFeatureModulation(1024, 1024, 1024, self.identity_channels, self.num_blocks),
-				AdaptiveFeatureModulation(1024, 512, 512, self.identity_channels, self.num_blocks)
+				AdaptiveFeatureModulation(1024, 1024, 1024, self.config.get('identity_channels'), self.config.get('num_blocks')),
+				AdaptiveFeatureModulation(1024, 1024, 2048, self.config.get('identity_channels'), self.config.get('num_blocks')),
+				AdaptiveFeatureModulation(1024, 1024, 1024, self.config.get('identity_channels'), self.config.get('num_blocks')),
+				AdaptiveFeatureModulation(1024, 512, 512, self.config.get('identity_channels'), self.config.get('num_blocks'))
 			])
 
-		if self.output_size == 512:
+		if self.config.get('output_size') == 512:
 			layers.extend(
 			[
-				AdaptiveFeatureModulation(2048, 2048, 2048, self.identity_channels, self.num_blocks),
-				AdaptiveFeatureModulation(2048, 2048, 4096, self.identity_channels, self.num_blocks),
-				AdaptiveFeatureModulation(2048, 2048, 2048, self.identity_channels, self.num_blocks),
-				AdaptiveFeatureModulation(2048, 1024, 1024, self.identity_channels, self.num_blocks),
-				AdaptiveFeatureModulation(1024, 512, 512, self.identity_channels, self.num_blocks)
+				AdaptiveFeatureModulation(2048, 2048, 2048, self.config.get('identity_channels'), self.config.get('num_blocks')),
+				AdaptiveFeatureModulation(2048, 2048, 4096, self.config.get('identity_channels'), self.config.get('num_blocks')),
+				AdaptiveFeatureModulation(2048, 2048, 2048, self.config.get('identity_channels'), self.config.get('num_blocks')),
+				AdaptiveFeatureModulation(2048, 1024, 1024, self.config.get('identity_channels'), self.config.get('num_blocks')),
+				AdaptiveFeatureModulation(1024, 512, 512, self.config.get('identity_channels'), self.config.get('num_blocks'))
 			])
 
 		layers.extend(
 		[
-			AdaptiveFeatureModulation(512, 256, 256, self.identity_channels, self.num_blocks),
-			AdaptiveFeatureModulation(256, 128, 128, self.identity_channels, self.num_blocks),
-			AdaptiveFeatureModulation(128, 64, 64, self.identity_channels, self.num_blocks),
-			AdaptiveFeatureModulation(64, 3, 64, self.identity_channels, self.num_blocks)
+			AdaptiveFeatureModulation(512, 256, 256, self.config.get('identity_channels'), self.config.get('num_blocks')),
+			AdaptiveFeatureModulation(256, 128, 128, self.config.get('identity_channels'), self.config.get('num_blocks')),
+			AdaptiveFeatureModulation(128, 64, 64, self.config.get('identity_channels'), self.config.get('num_blocks')),
+			AdaptiveFeatureModulation(64, 3, 64, self.config.get('identity_channels'), self.config.get('num_blocks'))
 		])
 
 		return layers
@@ -69,40 +75,43 @@ class AAD(nn.Module):
 class AdaptiveFeatureModulation(nn.Module):
 	def __init__(self, input_channels : int, output_channels : int, attribute_channels : int, identity_channels : int, num_blocks : int) -> None:
 		super().__init__()
-		self.input_channels = input_channels
-		self.output_channels = output_channels
-		self.attribute_channels = attribute_channels
-		self.identity_channels = identity_channels
-		self.num_blocks = num_blocks
+		self.context =\
+		{
+			'input_channels': input_channels,
+			'output_channels': output_channels,
+			'attribute_channels': attribute_channels,
+			'identity_channels': identity_channels,
+			'num_blocks': num_blocks
+		}
 		self.primary_layers = self.create_primary_layers()
 		self.shortcut_layers = self.create_shortcut_layers()
 
 	def create_primary_layers(self) -> nn.ModuleList:
 		primary_layers = nn.ModuleList()
 
-		for index in range(self.num_blocks):
+		for index in range(self.context.get('num_blocks')):
 			primary_layers.extend(
 			[
-				FeatureModulation(self.input_channels, self.attribute_channels, self.identity_channels),
+				FeatureModulation(self.context.get('input_channels'), self.context.get('attribute_channels'), self.context.get('identity_channels')),
 				nn.ReLU(inplace = True)
 			])
 
-			if index < self.num_blocks - 1:
-				primary_layers.append(nn.Conv2d(self.input_channels, self.input_channels, kernel_size = 3, padding = 1, bias = False))
+			if index < self.context.get('num_blocks') - 1:
+				primary_layers.append(nn.Conv2d(self.context.get('input_channels'), self.context.get('input_channels'), kernel_size = 3, padding = 1, bias = False))
 			else:
-				primary_layers.append(nn.Conv2d(self.input_channels, self.output_channels, kernel_size = 3, padding = 1, bias = False))
+				primary_layers.append(nn.Conv2d(self.context.get('input_channels'), self.context.get('output_channels'), kernel_size = 3, padding = 1, bias = False))
 
 		return primary_layers
 
 	def create_shortcut_layers(self) -> nn.ModuleList:
 		shortcut_layers = nn.ModuleList()
 
-		if self.input_channels > self.output_channels:
+		if self.context.get('input_channels') > self.context.get('output_channels'):
 			shortcut_layers.extend(
 			[
-				FeatureModulation(self.input_channels, self.attribute_channels, self.identity_channels),
+				FeatureModulation(self.context.get('input_channels'), self.context.get('attribute_channels'), self.context.get('identity_channels')),
 				nn.ReLU(inplace = True),
-				nn.Conv2d(self.input_channels, self.output_channels, kernel_size = 3, padding = 1, bias = False)
+				nn.Conv2d(self.context.get('input_channels'), self.context.get('output_channels'), kernel_size = 3, padding = 1, bias = False)
 			])
 
 		return shortcut_layers
@@ -116,7 +125,7 @@ class AdaptiveFeatureModulation(nn.Module):
 			else:
 				primary_tensor = primary_layer(primary_tensor)
 
-		if self.input_channels > self.output_channels:
+		if self.context.get('input_channels') > self.context.get('output_channels'):
 			shortcut_tensor = input_tensor
 
 			for shortcut_layer in self.shortcut_layers:
@@ -133,7 +142,10 @@ class AdaptiveFeatureModulation(nn.Module):
 class FeatureModulation(nn.Module):
 	def __init__(self, input_channels : int, attribute_channels : int, identity_channels : int) -> None:
 		super().__init__()
-		self.input_channels = input_channels
+		self.context =\
+		{
+			'input_channels': input_channels
+		}
 		self.conv1 = nn.Conv2d(attribute_channels, input_channels, kernel_size = 1)
 		self.conv2 = nn.Conv2d(attribute_channels, input_channels, kernel_size = 1)
 		self.conv3 = nn.Conv2d(input_channels, 1, kernel_size = 1)
@@ -148,8 +160,8 @@ class FeatureModulation(nn.Module):
 		attribute_shift = self.conv2(attribute_embedding)
 		attribute_modulation = attribute_scale * temp_tensor + attribute_shift
 
-		identity_scale = self.linear2(identity_embedding).reshape(temp_tensor.shape[0], self.input_channels, 1, 1).expand_as(temp_tensor)
-		identity_shift = self.linear1(identity_embedding).reshape(temp_tensor.shape[0], self.input_channels, 1, 1).expand_as(temp_tensor)
+		identity_scale = self.linear2(identity_embedding).reshape(temp_tensor.shape[0], self.context.get('input_channels'), 1, 1).expand_as(temp_tensor)
+		identity_shift = self.linear1(identity_embedding).reshape(temp_tensor.shape[0], self.context.get('input_channels'), 1, 1).expand_as(temp_tensor)
 		identity_modulation = identity_scale * temp_tensor + identity_shift
 
 		temp_mask = torch.sigmoid(self.conv3(temp_tensor))

--- a/face_swapper/src/networks/aad.py
+++ b/face_swapper/src/networks/aad.py
@@ -13,7 +13,6 @@ class AAD(nn.Module):
 		self.config_output_channels = config_parser.getint('training.model.generator', 'output_channels')
 		self.config_output_size = config_parser.getint('training.model.generator', 'output_size')
 		self.config_num_blocks = config_parser.getint('training.model.generator', 'num_blocks')
-		self.config_parser = config_parser
 		self.pixel_shuffle_up_sample = PixelShuffleUpSample(self.config_identity_channels, self.config_output_channels)
 		self.layers = self.create_layers()
 

--- a/face_swapper/src/networks/aad.py
+++ b/face_swapper/src/networks/aad.py
@@ -9,53 +9,50 @@ from ..types import Attributes, Embedding
 class AAD(nn.Module):
 	def __init__(self, config_parser : ConfigParser) -> None:
 		super().__init__()
-		self.config =\
-		{
-			'identity_channels': config_parser.getint('training.model.generator', 'identity_channels'),
-			'output_channels': config_parser.getint('training.model.generator', 'output_channels'),
-			'output_size': config_parser.getint('training.model.generator', 'output_size'),
-			'num_blocks': config_parser.getint('training.model.generator', 'num_blocks')
-		}
+		self.config_identity_channels = config_parser.getint('training.model.generator', 'identity_channels')
+		self.config_output_channels = config_parser.getint('training.model.generator', 'output_channels')
+		self.config_output_size = config_parser.getint('training.model.generator', 'output_size')
+		self.config_num_blocks = config_parser.getint('training.model.generator', 'num_blocks')
 		self.config_parser = config_parser
-		self.pixel_shuffle_up_sample = PixelShuffleUpSample(self.config.get('identity_channels'), self.config.get('output_channels'))
+		self.pixel_shuffle_up_sample = PixelShuffleUpSample(self.config_identity_channels, self.config_output_channels)
 		self.layers = self.create_layers()
 
 	def create_layers(self) -> nn.ModuleList:
 		layers = nn.ModuleList()
 
-		if self.config.get('output_size') == 128:
+		if self.config_output_size == 128:
 			layers.extend(
 			[
-				AdaptiveFeatureModulation(512, 512, 512, self.config.get('identity_channels'), self.config.get('num_blocks')),
-				AdaptiveFeatureModulation(512, 512, 1024, self.config.get('identity_channels'), self.config.get('num_blocks')),
-				AdaptiveFeatureModulation(512, 512, 512, self.config.get('identity_channels'), self.config.get('num_blocks'))
+				AdaptiveFeatureModulation(512, 512, 512, self.config_identity_channels, self.config_num_blocks),
+				AdaptiveFeatureModulation(512, 512, 1024, self.config_identity_channels, self.config_num_blocks),
+				AdaptiveFeatureModulation(512, 512, 512, self.config_identity_channels, self.config_num_blocks)
 			])
 
-		if self.config.get('output_size') == 256:
+		if self.config_output_size == 256:
 			layers.extend(
 			[
-				AdaptiveFeatureModulation(1024, 1024, 1024, self.config.get('identity_channels'), self.config.get('num_blocks')),
-				AdaptiveFeatureModulation(1024, 1024, 2048, self.config.get('identity_channels'), self.config.get('num_blocks')),
-				AdaptiveFeatureModulation(1024, 1024, 1024, self.config.get('identity_channels'), self.config.get('num_blocks')),
-				AdaptiveFeatureModulation(1024, 512, 512, self.config.get('identity_channels'), self.config.get('num_blocks'))
+				AdaptiveFeatureModulation(1024, 1024, 1024, self.config_identity_channels, self.config_num_blocks),
+				AdaptiveFeatureModulation(1024, 1024, 2048, self.config_identity_channels, self.config_num_blocks),
+				AdaptiveFeatureModulation(1024, 1024, 1024, self.config_identity_channels, self.config_num_blocks),
+				AdaptiveFeatureModulation(1024, 512, 512, self.config_identity_channels, self.config_num_blocks)
 			])
 
-		if self.config.get('output_size') == 512:
+		if self.config_output_size == 512:
 			layers.extend(
 			[
-				AdaptiveFeatureModulation(2048, 2048, 2048, self.config.get('identity_channels'), self.config.get('num_blocks')),
-				AdaptiveFeatureModulation(2048, 2048, 4096, self.config.get('identity_channels'), self.config.get('num_blocks')),
-				AdaptiveFeatureModulation(2048, 2048, 2048, self.config.get('identity_channels'), self.config.get('num_blocks')),
-				AdaptiveFeatureModulation(2048, 1024, 1024, self.config.get('identity_channels'), self.config.get('num_blocks')),
-				AdaptiveFeatureModulation(1024, 512, 512, self.config.get('identity_channels'), self.config.get('num_blocks'))
+				AdaptiveFeatureModulation(2048, 2048, 2048, self.config_identity_channels, self.config_num_blocks),
+				AdaptiveFeatureModulation(2048, 2048, 4096, self.config_identity_channels, self.config_num_blocks),
+				AdaptiveFeatureModulation(2048, 2048, 2048, self.config_identity_channels, self.config_num_blocks),
+				AdaptiveFeatureModulation(2048, 1024, 1024, self.config_identity_channels, self.config_num_blocks),
+				AdaptiveFeatureModulation(1024, 512, 512, self.config_identity_channels, self.config_num_blocks)
 			])
 
 		layers.extend(
 		[
-			AdaptiveFeatureModulation(512, 256, 256, self.config.get('identity_channels'), self.config.get('num_blocks')),
-			AdaptiveFeatureModulation(256, 128, 128, self.config.get('identity_channels'), self.config.get('num_blocks')),
-			AdaptiveFeatureModulation(128, 64, 64, self.config.get('identity_channels'), self.config.get('num_blocks')),
-			AdaptiveFeatureModulation(64, 3, 64, self.config.get('identity_channels'), self.config.get('num_blocks'))
+			AdaptiveFeatureModulation(512, 256, 256, self.config_identity_channels, self.config_num_blocks),
+			AdaptiveFeatureModulation(256, 128, 128, self.config_identity_channels, self.config_num_blocks),
+			AdaptiveFeatureModulation(128, 64, 64, self.config_identity_channels, self.config_num_blocks),
+			AdaptiveFeatureModulation(64, 3, 64, self.config_identity_channels, self.config_num_blocks)
 		])
 
 		return layers
@@ -75,43 +72,40 @@ class AAD(nn.Module):
 class AdaptiveFeatureModulation(nn.Module):
 	def __init__(self, input_channels : int, output_channels : int, attribute_channels : int, identity_channels : int, num_blocks : int) -> None:
 		super().__init__()
-		self.context =\
-		{
-			'input_channels': input_channels,
-			'output_channels': output_channels,
-			'attribute_channels': attribute_channels,
-			'identity_channels': identity_channels,
-			'num_blocks': num_blocks
-		}
+		self.context_input_channels = input_channels
+		self.context_output_channels = output_channels
+		self.context_attribute_channels = attribute_channels
+		self.context_identity_channels = identity_channels
+		self.context_num_blocks = num_blocks
 		self.primary_layers = self.create_primary_layers()
 		self.shortcut_layers = self.create_shortcut_layers()
 
 	def create_primary_layers(self) -> nn.ModuleList:
 		primary_layers = nn.ModuleList()
 
-		for index in range(self.context.get('num_blocks')):
+		for index in range(self.context_num_blocks):
 			primary_layers.extend(
 			[
-				FeatureModulation(self.context.get('input_channels'), self.context.get('attribute_channels'), self.context.get('identity_channels')),
+				FeatureModulation(self.context_input_channels, self.context_attribute_channels, self.context_identity_channels),
 				nn.ReLU(inplace = True)
 			])
 
-			if index < self.context.get('num_blocks') - 1:
-				primary_layers.append(nn.Conv2d(self.context.get('input_channels'), self.context.get('input_channels'), kernel_size = 3, padding = 1, bias = False))
+			if index < self.context_num_blocks - 1:
+				primary_layers.append(nn.Conv2d(self.context_input_channels, self.context_input_channels, kernel_size = 3, padding = 1, bias = False))
 			else:
-				primary_layers.append(nn.Conv2d(self.context.get('input_channels'), self.context.get('output_channels'), kernel_size = 3, padding = 1, bias = False))
+				primary_layers.append(nn.Conv2d(self.context_input_channels, self.context_output_channels, kernel_size = 3, padding = 1, bias = False))
 
 		return primary_layers
 
 	def create_shortcut_layers(self) -> nn.ModuleList:
 		shortcut_layers = nn.ModuleList()
 
-		if self.context.get('input_channels') > self.context.get('output_channels'):
+		if self.context_input_channels > self.context_output_channels:
 			shortcut_layers.extend(
 			[
-				FeatureModulation(self.context.get('input_channels'), self.context.get('attribute_channels'), self.context.get('identity_channels')),
+				FeatureModulation(self.context_input_channels, self.context_attribute_channels, self.context_identity_channels),
 				nn.ReLU(inplace = True),
-				nn.Conv2d(self.context.get('input_channels'), self.context.get('output_channels'), kernel_size = 3, padding = 1, bias = False)
+				nn.Conv2d(self.context_input_channels, self.context_output_channels, kernel_size = 3, padding = 1, bias = False)
 			])
 
 		return shortcut_layers
@@ -125,7 +119,7 @@ class AdaptiveFeatureModulation(nn.Module):
 			else:
 				primary_tensor = primary_layer(primary_tensor)
 
-		if self.context.get('input_channels') > self.context.get('output_channels'):
+		if self.context_input_channels > self.context_output_channels:
 			shortcut_tensor = input_tensor
 
 			for shortcut_layer in self.shortcut_layers:
@@ -142,10 +136,7 @@ class AdaptiveFeatureModulation(nn.Module):
 class FeatureModulation(nn.Module):
 	def __init__(self, input_channels : int, attribute_channels : int, identity_channels : int) -> None:
 		super().__init__()
-		self.context =\
-		{
-			'input_channels': input_channels
-		}
+		self.context_input_channels = input_channels
 		self.conv1 = nn.Conv2d(attribute_channels, input_channels, kernel_size = 1)
 		self.conv2 = nn.Conv2d(attribute_channels, input_channels, kernel_size = 1)
 		self.conv3 = nn.Conv2d(input_channels, 1, kernel_size = 1)
@@ -160,8 +151,8 @@ class FeatureModulation(nn.Module):
 		attribute_shift = self.conv2(attribute_embedding)
 		attribute_modulation = attribute_scale * temp_tensor + attribute_shift
 
-		identity_scale = self.linear2(identity_embedding).reshape(temp_tensor.shape[0], self.context.get('input_channels'), 1, 1).expand_as(temp_tensor)
-		identity_shift = self.linear1(identity_embedding).reshape(temp_tensor.shape[0], self.context.get('input_channels'), 1, 1).expand_as(temp_tensor)
+		identity_scale = self.linear2(identity_embedding).reshape(temp_tensor.shape[0], self.context_input_channels, 1, 1).expand_as(temp_tensor)
+		identity_shift = self.linear1(identity_embedding).reshape(temp_tensor.shape[0], self.context_input_channels, 1, 1).expand_as(temp_tensor)
 		identity_modulation = identity_scale * temp_tensor + identity_shift
 
 		temp_mask = torch.sigmoid(self.conv3(temp_tensor))

--- a/face_swapper/src/networks/nld.py
+++ b/face_swapper/src/networks/nld.py
@@ -7,31 +7,28 @@ from torch import Tensor, nn
 class NLD(nn.Module):
 	def __init__(self, config_parser : ConfigParser) -> None:
 		super().__init__()
-		self.config =\
-		{
-			'input_channels': config_parser.getint('training.model.discriminator', 'input_channels'),
-			'num_filters': config_parser.getint('training.model.discriminator', 'num_filters'),
-			'kernel_size': config_parser.getint('training.model.discriminator', 'kernel_size'),
-			'num_layers': config_parser.getint('training.model.discriminator', 'num_layers')
-		}
+		self.config_input_channels = config_parser.getint('training.model.discriminator', 'input_channels')
+		self.config_num_filters = config_parser.getint('training.model.discriminator', 'num_filters')
+		self.config_kernel_size = config_parser.getint('training.model.discriminator', 'kernel_size')
+		self.config_num_layers = config_parser.getint('training.model.discriminator', 'num_layers')
 		self.layers = self.create_layers()
 		self.sequences = nn.Sequential(*self.layers)
 
 	def create_layers(self) -> nn.ModuleList:
-		padding = math.ceil((self.config.get('kernel_size') - 1) / 2)
-		current_filters = self.config.get('num_filters')
+		padding = math.ceil((self.config_kernel_size - 1) / 2)
+		current_filters = self.config_num_filters
 		layers = nn.ModuleList(
 		[
-			nn.Conv2d(self.config.get('input_channels'), current_filters, kernel_size = self.config.get('kernel_size'), stride = 2, padding = padding),
+			nn.Conv2d(self.config_input_channels, current_filters, kernel_size = self.config_kernel_size, stride = 2, padding = padding),
 			nn.LeakyReLU(0.2, True)
 		])
 
-		for _ in range(1, self.config.get('num_layers')):
+		for _ in range(1, self.config_num_layers):
 			previous_filters = current_filters
 			current_filters = min(current_filters * 2, 512)
 			layers +=\
 			[
-				nn.Conv2d(previous_filters, current_filters, kernel_size = self.config.get('kernel_size'), stride = 2, padding = padding),
+				nn.Conv2d(previous_filters, current_filters, kernel_size = self.config_kernel_size, stride = 2, padding = padding),
 				nn.InstanceNorm2d(current_filters),
 				nn.LeakyReLU(0.2, True)
 			]
@@ -40,10 +37,10 @@ class NLD(nn.Module):
 		current_filters = min(current_filters * 2, 512)
 		layers +=\
 		[
-			nn.Conv2d(previous_filters, current_filters, kernel_size = self.config.get('kernel_size'), padding = padding),
+			nn.Conv2d(previous_filters, current_filters, kernel_size = self.config_kernel_size, padding = padding),
 			nn.InstanceNorm2d(current_filters),
 			nn.LeakyReLU(0.2, True),
-			nn.Conv2d(current_filters, 1, kernel_size = self.config.get('kernel_size'), padding = padding)
+			nn.Conv2d(current_filters, 1, kernel_size = self.config_kernel_size, padding = padding)
 		]
 		return layers
 

--- a/face_swapper/src/networks/nld.py
+++ b/face_swapper/src/networks/nld.py
@@ -1,33 +1,37 @@
 import math
+from configparser import ConfigParser
 
 from torch import Tensor, nn
 
 
 class NLD(nn.Module):
-	def __init__(self, input_channels : int, num_filters : int, num_layers : int, kernel_size : int) -> None:
+	def __init__(self, config_parser : ConfigParser) -> None:
 		super().__init__()
-		self.input_channels = input_channels
-		self.num_filters = num_filters
-		self.num_layers = num_layers
-		self.kernel_size = kernel_size
+		self.config =\
+		{
+			'input_channels': config_parser.getint('training.model.discriminator', 'input_channels'),
+			'num_filters': config_parser.getint('training.model.discriminator', 'num_filters'),
+			'kernel_size': config_parser.getint('training.model.discriminator', 'kernel_size'),
+			'num_layers': config_parser.getint('training.model.discriminator', 'num_layers')
+		}
 		self.layers = self.create_layers()
 		self.sequences = nn.Sequential(*self.layers)
 
 	def create_layers(self) -> nn.ModuleList:
-		padding = math.ceil((self.kernel_size - 1) / 2)
-		current_filters = self.num_filters
+		padding = math.ceil((self.config.get('kernel_size') - 1) / 2)
+		current_filters = self.config.get('num_filters')
 		layers = nn.ModuleList(
 		[
-			nn.Conv2d(self.input_channels, current_filters, kernel_size = self.kernel_size, stride = 2, padding = padding),
+			nn.Conv2d(self.config.get('input_channels'), current_filters, kernel_size = self.config.get('kernel_size'), stride = 2, padding = padding),
 			nn.LeakyReLU(0.2, True)
 		])
 
-		for _ in range(1, self.num_layers):
+		for _ in range(1, self.config.get('num_layers')):
 			previous_filters = current_filters
 			current_filters = min(current_filters * 2, 512)
 			layers +=\
 			[
-				nn.Conv2d(previous_filters, current_filters, kernel_size = self.kernel_size, stride = 2, padding = padding),
+				nn.Conv2d(previous_filters, current_filters, kernel_size = self.config.get('kernel_size'), stride = 2, padding = padding),
 				nn.InstanceNorm2d(current_filters),
 				nn.LeakyReLU(0.2, True)
 			]
@@ -36,10 +40,10 @@ class NLD(nn.Module):
 		current_filters = min(current_filters * 2, 512)
 		layers +=\
 		[
-			nn.Conv2d(previous_filters, current_filters, kernel_size = self.kernel_size, padding = padding),
+			nn.Conv2d(previous_filters, current_filters, kernel_size = self.config.get('kernel_size'), padding = padding),
 			nn.InstanceNorm2d(current_filters),
 			nn.LeakyReLU(0.2, True),
-			nn.Conv2d(current_filters, 1, kernel_size = self.kernel_size, padding = padding)
+			nn.Conv2d(current_filters, 1, kernel_size = self.config.get('kernel_size'), padding = padding)
 		]
 		return layers
 

--- a/face_swapper/src/networks/unet.py
+++ b/face_swapper/src/networks/unet.py
@@ -106,7 +106,7 @@ class UNet(nn.Module):
 class UpSample(nn.Module):
 	def __init__(self, input_channels : int, output_channels : int) -> None:
 		super().__init__()
-		self.conv_transpose = nn.ConvTranspose2d(in_channels = input_channels, out_channels = output_channels, kernel_size = 4, stride = 2, padding = 1, bias = False)
+		self.conv_transpose = nn.ConvTranspose2d(input_channels, output_channels, kernel_size = 4, stride = 2, padding = 1, bias = False)
 		self.batch_norm = nn.BatchNorm2d(output_channels)
 		self.leaky_relu = nn.LeakyReLU(0.1, inplace = True)
 
@@ -121,7 +121,7 @@ class UpSample(nn.Module):
 class DownSample(nn.Module):
 	def __init__(self, input_channels : int, output_channels : int) -> None:
 		super().__init__()
-		self.conv = nn.Conv2d(in_channels = input_channels, out_channels = output_channels, kernel_size = 4, stride = 2, padding = 1, bias = False)
+		self.conv = nn.Conv2d(input_channels, output_channels, kernel_size = 4, stride = 2, padding = 1, bias = False)
 		self.batch_norm = nn.BatchNorm2d(output_channels)
 		self.leaky_relu = nn.LeakyReLU(0.1, inplace = True)
 

--- a/face_swapper/src/networks/unet.py
+++ b/face_swapper/src/networks/unet.py
@@ -1,3 +1,4 @@
+from configparser import ConfigParser
 from typing import Tuple
 
 import torch
@@ -5,9 +6,12 @@ from torch import Tensor, nn
 
 
 class UNet(nn.Module):
-	def __init__(self, output_size : int) -> None:
+	def __init__(self, config_parser : ConfigParser) -> None:
 		super().__init__()
-		self.output_size = output_size
+		self.config =\
+		{
+			'output_size': config_parser.getint('training.model.generator', 'output_size')
+		}
 		self.down_samples = self.create_down_samples()
 		self.up_samples = self.create_up_samples()
 
@@ -21,20 +25,20 @@ class UNet(nn.Module):
 			DownSample(256, 512)
 		])
 
-		if self.output_size == 128:
+		if self.config.get('output_size') == 128:
 			down_samples.extend(
 			[
 				DownSample(512, 512)
 			])
 
-		if self.output_size == 256:
+		if self.config.get('output_size') == 256:
 			down_samples.extend(
 			[
 				DownSample(512, 1024),
 				DownSample(1024, 1024)
 			])
 
-		if self.output_size == 512:
+		if self.config.get('output_size') == 512:
 			down_samples.extend(
 			[
 				DownSample(512, 1024),
@@ -47,20 +51,20 @@ class UNet(nn.Module):
 	def create_up_samples(self) -> nn.ModuleList:
 		up_samples = nn.ModuleList()
 
-		if self.output_size == 128:
+		if self.config.get('output_size') == 128:
 			up_samples.extend(
 			[
 				UpSample(512, 512)
 			])
 
-		if self.output_size == 256:
+		if self.config.get('output_size') == 256:
 			up_samples.extend(
 			[
 				UpSample(1024, 1024),
 				UpSample(2048, 512)
 			])
 
-		if self.output_size == 512:
+		if self.config.get('output_size') == 512:
 			up_samples.extend(
 			[
 				UpSample(2048, 2048),

--- a/face_swapper/src/networks/unet.py
+++ b/face_swapper/src/networks/unet.py
@@ -8,10 +8,7 @@ from torch import Tensor, nn
 class UNet(nn.Module):
 	def __init__(self, config_parser : ConfigParser) -> None:
 		super().__init__()
-		self.config =\
-		{
-			'output_size': config_parser.getint('training.model.generator', 'output_size')
-		}
+		self.config_output_size = config_parser.getint('training.model.generator', 'output_size')
 		self.down_samples = self.create_down_samples()
 		self.up_samples = self.create_up_samples()
 
@@ -25,20 +22,20 @@ class UNet(nn.Module):
 			DownSample(256, 512)
 		])
 
-		if self.config.get('output_size') == 128:
+		if self.config_output_size == 128:
 			down_samples.extend(
 			[
 				DownSample(512, 512)
 			])
 
-		if self.config.get('output_size') == 256:
+		if self.config_output_size == 256:
 			down_samples.extend(
 			[
 				DownSample(512, 1024),
 				DownSample(1024, 1024)
 			])
 
-		if self.config.get('output_size') == 512:
+		if self.config_output_size == 512:
 			down_samples.extend(
 			[
 				DownSample(512, 1024),
@@ -51,20 +48,20 @@ class UNet(nn.Module):
 	def create_up_samples(self) -> nn.ModuleList:
 		up_samples = nn.ModuleList()
 
-		if self.config.get('output_size') == 128:
+		if self.config_output_size == 128:
 			up_samples.extend(
 			[
 				UpSample(512, 512)
 			])
 
-		if self.config.get('output_size') == 256:
+		if self.config_output_size == 256:
 			up_samples.extend(
 			[
 				UpSample(1024, 1024),
 				UpSample(2048, 512)
 			])
 
-		if self.config.get('output_size') == 512:
+		if self.config_output_size == 512:
 			up_samples.extend(
 			[
 				UpSample(2048, 2048),

--- a/face_swapper/src/training.py
+++ b/face_swapper/src/training.py
@@ -1,7 +1,7 @@
 import os
-from configparser import ConfigParser
 import warnings
-from typing import Tuple, cast
+from configparser import ConfigParser
+from typing import Tuple
 
 import torch
 import torchvision
@@ -17,7 +17,7 @@ from .helper import calc_embedding
 from .models.discriminator import Discriminator
 from .models.generator import Generator
 from .models.loss import AdversarialLoss, AttributeLoss, DiscriminatorLoss, GazeLoss, IdentityLoss, MotionLoss, ReconstructionLoss
-from .types import Batch, BatchMode, Embedding, OptimizerSet, WarpTemplate
+from .types import Batch, Embedding, OptimizerSet
 
 warnings.filterwarnings('ignore', category = UserWarning, module = 'torch')
 

--- a/face_swapper/src/training.py
+++ b/face_swapper/src/training.py
@@ -28,17 +28,14 @@ CONFIG_PARSER.read('config.ini')
 class FaceSwapperTrainer(LightningModule):
 	def __init__(self, config_parser : ConfigParser) -> None:
 		super().__init__()
-		self.config =\
-		{
-			'embedder_path': config_parser.get('training.model', 'embedder_path'),
-			'gazer_path': config_parser.get('training.model', 'gazer_path'),
-			'motion_extractor_path': config_parser.get('training.model', 'motion_extractor_path'),
-			'learning_rate': config_parser.getfloat('training.trainer', 'learning_rate'),
-			'preview_frequency': config_parser.getint('training.trainer', 'preview_frequency')
-		}
-		self.embedder = torch.jit.load(self.config.get('embedder_path'), map_location = 'cpu').eval()  # type:ignore[no-untyped-call]
-		self.gazer = torch.jit.load(self.config.get('gazer_path'), map_location = 'cpu').eval()  # type:ignore[no-untyped-call]
-		self.motion_extractor = torch.jit.load(self.config.get('motion_extractor_path'), map_location = 'cpu').eval()  # type:ignore[no-untyped-call]
+		self.config_embedder_path = config_parser.get('training.model', 'embedder_path')
+		self.config_gazer_path = config_parser.get('training.model', 'gazer_path')
+		self.config_motion_extractor_path = config_parser.get('training.model', 'motion_extractor_path')
+		self.config_learning_rate = config_parser.getfloat('training.trainer', 'learning_rate')
+		self.config_preview_frequency = config_parser.getint('training.trainer', 'preview_frequency')
+		self.embedder = torch.jit.load(self.config_embedder_path, map_location = 'cpu').eval()
+		self.gazer = torch.jit.load(self.config_gazer_path, map_location = 'cpu').eval()
+		self.motion_extractor = torch.jit.load(self.config_motion_extractor_path, map_location = 'cpu').eval()
 		self.generator = Generator(config_parser)
 		self.discriminator = Discriminator(config_parser)
 		self.discriminator_loss = DiscriminatorLoss()
@@ -55,8 +52,8 @@ class FaceSwapperTrainer(LightningModule):
 		return output_tensor
 
 	def configure_optimizers(self) -> Tuple[OptimizerSet, OptimizerSet]:
-		generator_optimizer = torch.optim.AdamW(self.generator.parameters(), lr = self.config.get('learning_rate'), betas = (0.0, 0.999), weight_decay = 1e-4)
-		discriminator_optimizer = torch.optim.AdamW(self.discriminator.parameters(), lr = self.config.get('learning_rate'), betas = (0.0, 0.999), weight_decay = 1e-4)
+		generator_optimizer = torch.optim.AdamW(self.generator.parameters(), lr = self.config_learning_rate, betas = (0.0, 0.999), weight_decay = 1e-4)
+		discriminator_optimizer = torch.optim.AdamW(self.discriminator.parameters(), lr = self.config_learning_rate, betas = (0.0, 0.999), weight_decay = 1e-4)
 		generator_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(generator_optimizer, T_0 = 300, T_mult = 2)
 		discriminator_scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(discriminator_optimizer, T_0 = 300, T_mult = 2)
 
@@ -113,7 +110,7 @@ class FaceSwapperTrainer(LightningModule):
 		discriminator_optimizer.step()
 		self.untoggle_optimizer(discriminator_optimizer)
 
-		if self.global_step % self.config.get('preview_frequency') == 0:
+		if self.global_step % self.config_preview_frequency == 0:
 			self.generate_preview(source_tensor, target_tensor, generator_output_tensor)
 
 		self.log('generator_loss', generator_loss, prog_bar = True)
@@ -149,52 +146,43 @@ class FaceSwapperTrainer(LightningModule):
 
 
 def create_loaders(dataset : Dataset[Tensor]) -> Tuple[StatefulDataLoader[Tensor], StatefulDataLoader[Tensor]]:
-	config =\
-	{
-		'batch_size': CONFIG_PARSER.getint('training.loader', 'batch_size'),
-		'num_workers': CONFIG_PARSER.getint('training.loader', 'num_workers')
-	}
+	config_batch_size = CONFIG_PARSER.getint('training.loader', 'batch_size')
+	config_num_workers = CONFIG_PARSER.getint('training.loader', 'num_workers')
 
 	training_dataset, validate_dataset = split_dataset(dataset)
-	training_loader = StatefulDataLoader(training_dataset, batch_size = config.get('batch_size'), shuffle = True, num_workers = config.get('num_workers'), drop_last = True, pin_memory = True, persistent_workers = True)
-	validation_loader = StatefulDataLoader(validate_dataset, batch_size = config.get('batch_size'), shuffle = False, num_workers = config.get('num_workers'), pin_memory = True, persistent_workers = True)
+	training_loader = StatefulDataLoader(training_dataset, batch_size = config_batch_size, shuffle = True, num_workers = config_num_workers, drop_last = True, pin_memory = True, persistent_workers = True)
+	validation_loader = StatefulDataLoader(validate_dataset, batch_size = config_batch_size, shuffle = False, num_workers = config_num_workers, pin_memory = True, persistent_workers = True)
 	return training_loader, validation_loader
 
 
 def split_dataset(dataset : Dataset[Tensor]) -> Tuple[Dataset[Tensor], Dataset[Tensor]]:
-	config =\
-	{
-		'split_ratio': CONFIG_PARSER.getfloat('training.loader', 'split_ratio')
-	}
+	config_split_ratio = CONFIG_PARSER.getfloat('training.loader', 'split_ratio')
 
 	dataset_size = len(dataset) # type:ignore[arg-type]
-	training_size = int(dataset_size * config.get('split_ratio'))
+	training_size = int(dataset_size * config_split_ratio)
 	validation_size = int(dataset_size - training_size)
 	training_dataset, validate_dataset = random_split(dataset, [ training_size, validation_size ])
 	return training_dataset, validate_dataset
 
 
 def create_trainer() -> Trainer:
-	config =\
-	{
-		'max_epochs': CONFIG_PARSER.getint('training.trainer', 'max_epochs'),
-		'precision': CONFIG_PARSER.get('training.trainer', 'precision'),
-		'directory_path': CONFIG_PARSER.get('training.output', 'directory_path'),
-		'file_pattern': CONFIG_PARSER.get('training.output', 'file_pattern')
-	}
+	config_max_epochs = CONFIG_PARSER.getint('training.trainer', 'max_epochs')
+	config_precision = CONFIG_PARSER.get('training.trainer', 'precision')
+	config_directory_path = CONFIG_PARSER.get('training.output', 'directory_path')
+	config_file_pattern = CONFIG_PARSER.get('training.output', 'file_pattern')
 	logger = TensorBoardLogger('.logs', name = 'face_swapper')
 
 	return Trainer(
 		logger = logger,
 		log_every_n_steps = 10,
-		max_epochs = config.get('max_epochs'),
-		precision = config.get('precision'),
+		max_epochs = config_max_epochs,
+		precision = config_precision,
 		callbacks =
 		[
 			ModelCheckpoint(
 				monitor = 'generator_loss',
-				dirpath = config.get('directory_path'),
-				filename = config.get('file_pattern'),
+				dirpath = config_directory_path,
+				filename = config_file_pattern,
 				every_n_train_steps = 1000,
 				save_top_k = 3,
 				save_last = True
@@ -205,10 +193,7 @@ def create_trainer() -> Trainer:
 
 
 def train() -> None:
-	config =\
-	{
-		'resume_path': CONFIG_PARSER.get('training.output', 'resume_path')
-	}
+	config_resume_path = CONFIG_PARSER.get('training.output', 'resume_path')
 
 	if torch.cuda.is_available():
 		torch.set_float32_matmul_precision('high')
@@ -218,7 +203,7 @@ def train() -> None:
 	face_swapper_trainer = FaceSwapperTrainer(CONFIG_PARSER)
 	trainer = create_trainer()
 
-	if os.path.isfile(config.get('resume_path')):
-		trainer.fit(face_swapper_trainer, training_loader, validation_loader, ckpt_path = config.get('resume_path'))
+	if os.path.isfile(config_resume_path):
+		trainer.fit(face_swapper_trainer, training_loader, validation_loader, ckpt_path = config_resume_path)
 	else:
 		trainer.fit(face_swapper_trainer, training_loader, validation_loader)

--- a/face_swapper/src/training.py
+++ b/face_swapper/src/training.py
@@ -39,10 +39,9 @@ class FaceSwapperTrainer(LightningModule):
 		self.embedder = torch.jit.load(self.config.get('embedder_path'), map_location = 'cpu').eval()  # type:ignore[no-untyped-call]
 		self.gazer = torch.jit.load(self.config.get('gazer_path'), map_location = 'cpu').eval()  # type:ignore[no-untyped-call]
 		self.motion_extractor = torch.jit.load(self.config.get('motion_extractor_path'), map_location = 'cpu').eval()  # type:ignore[no-untyped-call]
-
 		self.generator = Generator(config_parser)
 		self.discriminator = Discriminator(config_parser)
-		self.discriminator_loss = DiscriminatorLoss(config_parser)
+		self.discriminator_loss = DiscriminatorLoss()
 		self.adversarial_loss = AdversarialLoss(config_parser)
 		self.attribute_loss = AttributeLoss(config_parser)
 		self.reconstruction_loss = ReconstructionLoss(config_parser, self.embedder)

--- a/face_swapper/tests/test_networks.py
+++ b/face_swapper/tests/test_networks.py
@@ -1,3 +1,5 @@
+from configparser import ConfigParser
+
 import pytest
 import torch
 
@@ -7,18 +9,17 @@ from face_swapper.src.networks.unet import UNet
 
 @pytest.mark.parametrize('output_size', [ 128, 256, 512 ])
 def test_aad_with_unet(output_size : int) -> None:
-	identity_channels = 512
-	output_channels = 1024
-	if output_size == 128:
-		output_channels = 2048
-	if output_size == 256:
-		output_channels = 4096
-	if output_size == 512:
-		output_channels = 8192
-	num_blocks = 2
+	config_parser = ConfigParser()
+	config_parser['training.model.generator'] =\
+	{
+		'identity_channels': '512',
+		'output_channels': str(output_size * 16),
+		'output_size': str(output_size),
+		'num_blocks': '2'
+	}
 
-	generator = AAD(identity_channels, output_channels, output_size, num_blocks).eval()
-	encoder = UNet(output_size).eval()
+	generator = AAD(config_parser).eval()
+	encoder = UNet(config_parser).eval()
 
 	source_tensor = torch.randn(1, 512)
 	target_tensor = torch.randn(1, 3, output_size, output_size)

--- a/face_swapper/tests/test_networks.py
+++ b/face_swapper/tests/test_networks.py
@@ -10,13 +10,16 @@ from face_swapper.src.networks.unet import UNet
 @pytest.mark.parametrize('output_size', [ 128, 256, 512 ])
 def test_aad_with_unet(output_size : int) -> None:
 	config_parser = ConfigParser()
-	config_parser['training.model.generator'] =\
+	config_parser.read_dict(
 	{
-		'identity_channels': '512',
-		'output_channels': str(output_size * 16),
-		'output_size': str(output_size),
-		'num_blocks': '2'
-	}
+		'training.model.generator':
+		{
+			'identity_channels': '512',
+			'output_channels': str(output_size * 16),
+			'output_size': str(output_size),
+			'num_blocks': '2'
+		}
+	})
 
 	generator = AAD(config_parser).eval()
 	encoder = UNet(config_parser).eval()


### PR DESCRIPTION
At some point I had to introduce `self.context` as the constructor was based on parameters only. Mixing parameters with `config_parser` felt like a bad option.

Storing the config in a dict like `self.config` came with the downside that the individual types got lost, so I had to revert every config dict and instead introduce prefixed `config_` variables.

Please double check about `eval()` changes.