### PR TITLE
Fix AAD naming, Attribute vs. Embedding

### DIFF
--- a/face_swapper/README.md
+++ b/face_swapper/README.md
@@ -51,7 +51,7 @@ face_parser_path = .models/face_parser.pt
 
 ```
 [training.model.generator]
-identity_channels = 512
+source_channels = 512
 output_channels = 4096
 output_size = 256
 num_blocks = 2

--- a/face_swapper/config.ini
+++ b/face_swapper/config.ini
@@ -17,7 +17,7 @@ motion_extractor_path =
 face_parser_path =
 
 [training.model.generator]
-identity_channels =
+source_channels =
 output_channels =
 output_size =
 num_blocks =

--- a/face_swapper/src/networks/aad.py
+++ b/face_swapper/src/networks/aad.py
@@ -65,7 +65,7 @@ class AAD(nn.Module):
 			temp_tensor = layer(temp_tensors, source_embedding, target_attribute)
 			temp_tensors = nn.functional.interpolate(temp_tensor, scale_factor = 2, mode = 'bilinear', align_corners = False)
 
-		target_attribute = target_attributes[-1],
+		target_attribute = target_attributes[-1]
 		temp_tensors = self.layers[-1](temp_tensors, source_embedding, target_attribute)
 		output_tensor = torch.tanh(temp_tensors)
 		return output_tensor

--- a/face_swapper/tests/test_networks.py
+++ b/face_swapper/tests/test_networks.py
@@ -15,7 +15,7 @@ def test_aad_with_unet(output_size : int) -> None:
 	{
 		'training.model.generator':
 		{
-			'identity_channels': '512',
+			'source_channels': '512',
 			'output_channels': str(output_size * 16),
 			'output_size': str(output_size),
 			'num_blocks': '2'


### PR DESCRIPTION
Sorting out Attribute vs. Embedding in AAD generator, flip parameter order (source first, target second)

Deepseek:

> The changes between the two files are non-functional and limited to variable and parameter renaming. The logic of the code remains the same. The modifications appear to be aimed at improving code readability and maintainability.

@harisreedhar please post-review